### PR TITLE
Ability to disable amazon's DRM

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,7 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+    buildConfigField "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")
   }
 
   buildTypes {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-    buildConfigField "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")
+    buildConfigField "boolean", "IS_AMAZON_DRM_ENABLED", getExtOrDefault("isAmazonDrmEnabled")
   }
 
   buildTypes {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,7 +7,7 @@ RNIap_ndkversion=23.1.7779620
 RNIap_playServicesVersion=18.1.0
 RNIap_amazonSdkVersion=3.0.4
 RNIap_playBillingSdkVersion=7.0.0
-RNIap_enableAmazonDrm=true
+RNIap_isAmazonDrmEnabled=true
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,6 +7,7 @@ RNIap_ndkversion=23.1.7779620
 RNIap_playServicesVersion=18.1.0
 RNIap_amazonSdkVersion=3.0.4
 RNIap_playBillingSdkVersion=7.0.0
+RNIap_enableAmazonDrm=true
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/android/src/amazon/java/com/dooboolab/rniap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/rniap/RNIapAmazonModule.kt
@@ -57,40 +57,46 @@ class RNIapAmazonModule(
 
     @ReactMethod
     fun verifyLicense(promise: Promise) {
-        try {
-            LicensingService.verifyLicense(reactApplicationContext) { licenseResponse ->
-                when (
-                    val status: LicenseResponse.RequestStatus =
-                        licenseResponse.requestStatus
-                ) {
-                    LicenseResponse.RequestStatus.LICENSED -> {
-                        Log.d(TAG, "LicenseResponse status: $status")
-                        promise.resolve("LICENSED")
-                    }
-                    LicenseResponse.RequestStatus.NOT_LICENSED -> {
-                        Log.d(TAG, "LicenseResponse status: $status")
-                        promise.resolve("NOT_LICENSED")
-                    }
-                    LicenseResponse.RequestStatus.EXPIRED -> {
-                        Log.d(TAG, "LicenseResponse status: $status")
-                        promise.resolve("EXPIRED")
-                    }
-                    LicenseResponse.RequestStatus.ERROR_VERIFICATION -> {
-                        Log.d(TAG, "LicenseResponse status: $status")
-                        promise.resolve("ERROR_VERIFICATION")
-                    }
-                    LicenseResponse.RequestStatus.ERROR_INVALID_LICENSING_KEYS -> {
-                        Log.d(TAG, "LicenseResponse status: $status")
-                        promise.resolve("ERROR_INVALID_LICENSING_KEYS")
-                    }
-                    LicenseResponse.RequestStatus.UNKNOWN_ERROR -> {
-                        Log.d(TAG, "LicenseResponse status: $status")
-                        promise.resolve("UNKNOWN_ERROR")
+        if (BuildConfig.ENABLE_AMAZON_DRM) {
+            Log.d(TAG, "Amazon's DRM is enabled")
+            try {
+                LicensingService.verifyLicense(reactApplicationContext) { licenseResponse ->
+                    when (
+                        val status: LicenseResponse.RequestStatus =
+                            licenseResponse.requestStatus
+                    ) {
+                        LicenseResponse.RequestStatus.LICENSED -> {
+                            Log.d(TAG, "LicenseResponse status: $status")
+                            promise.resolve("LICENSED")
+                        }
+                        LicenseResponse.RequestStatus.NOT_LICENSED -> {
+                            Log.d(TAG, "LicenseResponse status: $status")
+                            promise.resolve("NOT_LICENSED")
+                        }
+                        LicenseResponse.RequestStatus.EXPIRED -> {
+                            Log.d(TAG, "LicenseResponse status: $status")
+                            promise.resolve("EXPIRED")
+                        }
+                        LicenseResponse.RequestStatus.ERROR_VERIFICATION -> {
+                            Log.d(TAG, "LicenseResponse status: $status")
+                            promise.resolve("ERROR_VERIFICATION")
+                        }
+                        LicenseResponse.RequestStatus.ERROR_INVALID_LICENSING_KEYS -> {
+                            Log.d(TAG, "LicenseResponse status: $status")
+                            promise.resolve("ERROR_INVALID_LICENSING_KEYS")
+                        }
+                        LicenseResponse.RequestStatus.UNKNOWN_ERROR -> {
+                            Log.d(TAG, "LicenseResponse status: $status")
+                            promise.resolve("UNKNOWN_ERROR")
+                        }
                     }
                 }
+            } catch (exception: Exception) {
+                promise.reject("Error while attempting to check for License", exception)
             }
-        } catch (exception: Exception) {
-            promise.reject("Error while attempting to check for License", exception)
+        } else {
+            Log.d(TAG, "Amazon's DRM is disabled")
+            promise.resolve("NOT_LICENSED")
         }
     }
 

--- a/android/src/amazon/java/com/dooboolab/rniap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/rniap/RNIapAmazonModule.kt
@@ -57,7 +57,7 @@ class RNIapAmazonModule(
 
     @ReactMethod
     fun verifyLicense(promise: Promise) {
-        if (BuildConfig.ENABLE_AMAZON_DRM) {
+        if (BuildConfig.IS_AMAZON_DRM_ENABLED) {
             Log.d(TAG, "Amazon's DRM is enabled")
             try {
                 LicensingService.verifyLicense(reactApplicationContext) { licenseResponse ->

--- a/docs/docs/guides/amazon-iap.mdx
+++ b/docs/docs/guides/amazon-iap.mdx
@@ -46,6 +46,22 @@ Add the code below in `android/app/proguard-rules.pro`:
 + -keepattributes *Annotation*
 ```
 
+## Amazon's DRM protection
+
+This package includes Amazon's DRM (Digital Rights Management) protection enabled by default. Amazon's DRM allows license verification for your app, ensuring compliance and protection of your digital content. For more details, refer to the following resources:
+1. [DRM Overview](https://developer.amazon.com/docs/in-app-purchasing/drm-overview.html)
+2. [DRM for Android](https://developer.amazon.com/docs/in-app-purchasing/drm-android.html)
+
+### Disabling Amazon's DRM
+
+In certain cases, you may prefer not to use Amazon's DRM solution and instead implement your own custom DRM. To disable Amazon's DRM, simply add the following property to your project's `gradle.properties` file:
+
+```java
+isAmazonDrmEnabled=false
+```
+
+This setting overrides the default behavior, disabling Amazon's DRM for your app.
+
 ## Testing in development
 
 To run the example app, with the amazon provider, run:

--- a/plugin/__tests__/fixtures/buildGradleFiles.ts
+++ b/plugin/__tests__/fixtures/buildGradleFiles.ts
@@ -20,7 +20,7 @@ android {
         versionCode 34
         versionName "1.16.2"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-        buildConfigField "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")`;
+        buildConfigField "boolean", "IS_AMAZON_DRM_ENABLED", getExtOrDefault("isAmazonDrmEnabled")`;
 
 const appBuildGradleWithPlayStoreIAP = `
 apply plugin: "com.android.application"
@@ -45,7 +45,7 @@ missingDimensionStrategy "store", "play"
         versionCode 34
         versionName "1.16.2"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-        buildConfigField "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")`;
+        buildConfigField "boolean", "IS_AMAZON_DRM_ENABLED", getExtOrDefault("isAmazonDrmEnabled")`;
 
 const appBuildGradleWithAmazonStoreIAP = `
 apply plugin: "com.android.application"

--- a/plugin/__tests__/fixtures/buildGradleFiles.ts
+++ b/plugin/__tests__/fixtures/buildGradleFiles.ts
@@ -20,7 +20,7 @@ android {
         versionCode 34
         versionName "1.16.2"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-        enableAmazonDrm "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")`;
+        buildConfigField "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")`;
 
 const appBuildGradleWithPlayStoreIAP = `
 apply plugin: "com.android.application"
@@ -44,7 +44,8 @@ missingDimensionStrategy "store", "play"
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 34
         versionName "1.16.2"
-        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()`;
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+        buildConfigField "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")`;
 
 const appBuildGradleWithAmazonStoreIAP = `
 apply plugin: "com.android.application"

--- a/plugin/__tests__/fixtures/buildGradleFiles.ts
+++ b/plugin/__tests__/fixtures/buildGradleFiles.ts
@@ -19,7 +19,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 34
         versionName "1.16.2"
-        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()`;
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+        enableAmazonDrm "boolean", "ENABLE_AMAZON_DRM", getExtOrDefault("enableAmazonDrm")`;
 
 const appBuildGradleWithPlayStoreIAP = `
 apply plugin: "com.android.application"


### PR DESCRIPTION
In some cases, users want to manage the DRM with their own solution and not use Amazon's DRM. In the past, this was possible by unchecking the DRM option from Amazon's Developer console, but now you can only do it from their SDK.

The `react-native-iap` module by default will enable Amazon's DRM, but if a user doesn't want to leverage it, there is no option to disable it.

With this PR a user can easily disable it by adding `isAmazonDrmEnabled=false` to their **gradle.properties** file.
The default will be `true`

![Screenshot 2024-09-19 at 13 32 53](https://github.com/user-attachments/assets/aeec221d-3ba0-4564-a2dc-5ef3eeb15073)


