### PR TITLE
fix: android build error with React Native 0.76

### DIFF
--- a/android/src/main/java/com/dooboolab/rniap/PromiseUtlis.kt
+++ b/android/src/main/java/com/dooboolab/rniap/PromiseUtlis.kt
@@ -37,7 +37,7 @@ fun Promise.safeReject(
     throwable: Throwable?,
 ) {
     try {
-        this.reject(code, message, throwable)
+        this.reject(code ?: "", message, throwable)
     } catch (oce: ObjectAlreadyConsumedException) {
         Log.d(TAG, "Already consumed ${oce.message}")
     }


### PR DESCRIPTION
When using React Native 0.76 the Android build fails with an error:
```
java/com/dooboolab/RNIap/PromiseUtlis.kt:40:21 Type mismatch: inferred type is String? but String was expected
```

The issue seems to be caused by the fact that in RN 0.76 the Promise class was rewritten from Java to Kotlin and the code parameter of the reject method is a non-nullable String now: https://github.com/facebook/react-native/commit/de73e44569fd2932fe5683f7a392f37d866e5d35#diff-74cbd5a9d82e4c21dbc37dd72a92e31542e574dc6425d2454c3ce53e71e08bbeR31 but in react-native-iap it is called with a nullable string: https://github.com/hyochan/react-native-iap/blob/12.15.6/android/src/main/java/com/dooboolab/rniap/PromiseUtlis.kt#L40.

This change updates that call to use an empty string "" for code if for some reason it's null.

Fixes https://github.com/hyochan/react-native-iap/issues/2871