### PR TITLE
refactor: make the code parameter of safeReject non-nullable

### DIFF
--- a/android/src/main/java/com/dooboolab/rniap/PromiseUtils.kt
+++ b/android/src/main/java/com/dooboolab/rniap/PromiseUtils.kt
@@ -33,7 +33,7 @@ object PromiseUtils {
 
     fun rejectPromisesForKey(
         key: String,
-        code: String?,
+        code: String,
         message: String?,
         err: Exception?,
     ) {

--- a/android/src/main/java/com/dooboolab/rniap/PromiseUtlis.kt
+++ b/android/src/main/java/com/dooboolab/rniap/PromiseUtlis.kt
@@ -22,22 +22,22 @@ fun Promise.safeResolve(value: Any?) {
 fun Promise.safeReject(message: String) = this.safeReject(message, null, null)
 
 fun Promise.safeReject(
-    code: String?,
+    code: String,
     message: String?,
 ) = this.safeReject(code, message, null)
 
 fun Promise.safeReject(
-    code: String?,
+    code: String,
     throwable: Throwable?,
 ) = this.safeReject(code, null, throwable)
 
 fun Promise.safeReject(
-    code: String?,
+    code: String,
     message: String?,
     throwable: Throwable?,
 ) {
     try {
-        this.reject(code ?: "", message, throwable)
+        this.reject(code, message, throwable)
     } catch (oce: ObjectAlreadyConsumedException) {
         Log.d(TAG, "Already consumed ${oce.message}")
     }


### PR DESCRIPTION
The reject method of Promise class became non-nullable in React Native 0.76 after rewriting it from Java to Kotlin. We fixed it being called with a nullable value in https://github.com/hyochan/react-native-iap/pull/2872 by providing and empty string as a fallback if it happens to be null. But after more investigation it seems like it's not called with a value that could be null anywhere in the code, so a better solution would be to just update the type of the `code` parameter to be non-nullable.