### PR TITLE
Remove useless React-Codegen pod dependency

### DIFF
--- a/RNIap.podspec
+++ b/RNIap.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
 
-    s.dependency "React-Codegen"
     s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"


### PR DESCRIPTION
This dependency is not needed (empty dependency) and is affecting building tvos projects using react-native-iap:
```
[!] The platform of the target `project-tvOS` (tvOS 15.1) is not compatible with `React-Codegen (0.1.0)`, which does not support `tvOS`.
```