### PR TITLE
fix: handle nullable strings in react-native-iap kotlin code

### DIFF
--- a/android/src/amazon/java/com/dooboolab/rniap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/rniap/RNIapAmazonModule.kt
@@ -113,8 +113,9 @@ class RNIapAmazonModule(
         var ii = 0
         val skuSize = skuArr.size()
         while (ii < skuSize) {
-            val sku = skuArr.getString(ii)
-            productSkus.add(sku)
+            skuArr.getString(ii)?.let { sku ->
+                productSkus.add(sku)
+            }
             ii++
         }
         PromiseUtils.addPromiseForKey(PROMISE_GET_PRODUCT_DATA, promise)

--- a/android/src/main/java/com/dooboolab/rniap/PromiseUtlis.kt
+++ b/android/src/main/java/com/dooboolab/rniap/PromiseUtlis.kt
@@ -1,8 +1,8 @@
 package com.dooboolab.rniap
 
 import android.util.Log
-import com.facebook.react.bridge.ObjectAlreadyConsumedException
 import com.facebook.react.bridge.Promise
+import java.lang.RuntimeException
 
 /**
  * Extension functions used to simplify promise handling since we don't
@@ -14,8 +14,8 @@ const val TAG = "IapPromises"
 fun Promise.safeResolve(value: Any?) {
     try {
         this.resolve(value)
-    } catch (oce: ObjectAlreadyConsumedException) {
-        Log.d(TAG, "Already consumed ${oce.message}")
+    } catch (e: RuntimeException) {
+        Log.d(TAG, "Already consumed ${e.message}")
     }
 }
 
@@ -38,7 +38,7 @@ fun Promise.safeReject(
 ) {
     try {
         this.reject(code, message, throwable)
-    } catch (oce: ObjectAlreadyConsumedException) {
-        Log.d(TAG, "Already consumed ${oce.message}")
+    } catch (e: RuntimeException) {
+        Log.d(TAG, "Already consumed ${e.message}")
     }
 }

--- a/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
@@ -252,7 +252,7 @@ class RNIapModule(
             val skuList = mutableListOf<QueryProductDetailsParams.Product>()
             for (i in 0 until skuArr.size()) {
                 if (skuArr.getType(i) == ReadableType.String) {
-                    skuArr.getString(i).let { sku ->
+                    skuArr.getString(i)?.let { sku ->
                         skuList.add(
                             QueryProductDetailsParams.Product
                                 .newBuilder()
@@ -441,7 +441,7 @@ class RNIapModule(
                     item.putString("purchaseToken", purchase.purchaseToken)
                     item.putString("dataAndroid", purchase.originalJson)
                     item.putString("signatureAndroid", purchase.signature)
-                    item.putString("developerPayload", purchase.developerPayload)
+                    item.putString("developerPayload", purchase.developerPayload.orEmpty())
                     items.pushMap(item)
                 }
                 promise.safeResolve(items)
@@ -501,8 +501,7 @@ class RNIapModule(
                     }
                     var productDetailParams = BillingFlowParams.ProductDetailsParams.newBuilder().setProductDetails(selectedSku)
                     if (type == BillingClient.ProductType.SUBS) {
-                        offerTokenArr.getString(index).let { offerToken ->
-                            // null check for older versions of RN
+                        offerTokenArr.getString(index)?.let { offerToken ->
                             productDetailParams = productDetailParams.setOfferToken(offerToken)
                         }
                     }
@@ -717,10 +716,11 @@ class RNIapModule(
             billingClient.getBillingConfigAsync(
                 GetBillingConfigParams.newBuilder().build(),
                 BillingConfigResponseListener { result: BillingResult, config: BillingConfig? ->
-                    if (result.getResponseCode() == BillingClient.BillingResponseCode.OK) {
-                        promise.safeResolve(config?.getCountryCode())
+                    if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                        promise.safeResolve(config?.countryCode.orEmpty())
                     } else {
-                        promise.safeReject(result?.getResponseCode().toString(), result?.getDebugMessage())
+                        val debugMessage = result.debugMessage.orEmpty()
+                        promise.safeReject(result.responseCode.toString(), debugMessage)
                     }
                 },
             )


### PR DESCRIPTION
Fixed type mismatch errors in RNIapModule.kt by properly handling nullable strings using orEmpty()