### PR TITLE
fix: add missing import in example

### DIFF
--- a/docs/docs/guides/purchases.mdx
+++ b/docs/docs/guides/purchases.mdx
@@ -33,6 +33,7 @@ import {
   purchaseUpdatedListener,
   type ProductPurchase,
   type PurchaseError,
+  finishTransaction
   flushFailedPurchasesCachedAsPendingAndroid,
 } from 'react-native-iap';
 


### PR DESCRIPTION
- `finishTransaction` import was missing from the code snippet