### PR TITLE
feat(docs): add link to expo-iap in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 ## Announcement
 
-Announcing the Migration of react-native-iap to an Expo Module for Improved Maintenance and Compatibility in [discussion #2754](https://github.com/hyochan/react-native-iap/discussions/2754).
+Announcing the Migration of react-native-iap to an Expo Module for Improved Maintenance and Compatibility in [discussion #2754](https://github.com/hyochan/react-native-iap/discussions/2754). 
+
+The [expo-iap](https://github.com/hyochan/expo-iap) library is now ready to use, with support for StoreKit 2 and Google Play Billing.
 
 ## Documentation
 


### PR DESCRIPTION
### **Description:**

I think we need add expo-iap to all documentation references, not only react-native-iap, but also to react-native-directories and expo itself, for community attention and better open-source maintaining 

### **Why I add this change:**

expo-iap is hard to find if you skip announcement of migration, but it can be very helpful for any developer, especially who want library with new architecture or expo support. Also expo-iap provide only StoreKit 2 and Google Play Billing, makes API and use cases more understandable

