### PR TITLE
feat: sync with expo-iap and add StoreKit 2 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,39 +10,26 @@
 
 ---
 
-## Announcement
+## 🚨 Important Announcement: Migration to expo-iap
 
-Announcing the Migration of react-native-iap to an Expo Module for Improved Maintenance and Compatibility in [discussion #2754](https://github.com/hyochan/react-native-iap/discussions/2754). 
+**react-native-iap will be replaced by [expo-iap](https://github.com/hyochan/expo-iap)** for improved maintenance and better compatibility with modern React Native development.
 
-The [expo-iap](https://github.com/hyochan/expo-iap) library is now ready to use, with support for StoreKit 2 and Google Play Billing.
+### Why the change?
+- Better maintenance and faster updates
+- Full StoreKit 2 support for iOS
+- Modern architecture using Expo Modules
+- Works with both Expo and bare React Native projects
+
+### Learn more
+- 📢 [Official announcement on X](https://x.com/hyodotdev/status/1939420943665049961)
+- 💬 [Discussion #2754](https://github.com/hyochan/react-native-iap/discussions/2754)
+- 🚀 [expo-iap repository](https://github.com/hyochan/expo-iap)
+
+The [expo-iap](https://github.com/hyochan/expo-iap) library is production-ready with full support for StoreKit 2 and Google Play Billing Library v6+.
 
 ## Documentation
 
 Read the [documentation](https://react-native-iap.hyo.dev). See the [troubleshooting](https://react-native-iap.hyo.dev/docs/guides/troubleshooting#common-issues) for the common issues to avoid.
-
-## Logs
-
-- Version `12.0.0`: Implements Amazon 3.x SDK including the new DRM verification.
-
-- Version `11.0.0`: The module migrates OS sdk to [storekit2](https://developer.apple.com/videos/play/wwdc2021/10114). [andresesfm](https://github.com/andresesfm) is working hard on this.
-
-  ```
-  yarn add react-native-iap@next
-  ```
-
-- Version `10.0.0` is a maintenance build. Many internal refactorings and clean up of the code. Special thanks to [jeremybarbet](https://github.com/jeremybarbet) for his contributions. Most notably all methods now take an object parameter instead of separate parameters. Please help us test
-
-- Version `9.0.0` The module migrates android sdk to [play billing library v5](https://qonversion.io/blog/google-play-billing-library-5-0). Our core maintainers [andresesfm](https://github.com/andresesfm) and [jeremybarbet](https://github.com/jeremybarbet) worked hard on this.
-
-- Version `8.0.0` has finally landed in Jan 28th. Since this is early release, please use it with caution 🚧. We recommend user to use `>=8.0.0` with react-native `>=0.65.1`. The `next` package is no longer updated until we organize the roadmap for `9.0.0`.
-
-- Version `8.0.0` is currently in release candidate. The module is completely rewritten with `Kotlin` and `Swift` for maintenance issue by [andresesfm](https://github.com/andresesfm) 🔆. You may install this for early preview.
-
-- React Native IAP hook is out. You can see [medium post](https://medium.com/hyochan/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
-
-- The `react-native-iap` module hasn't been maintained well recently. We are thinking of participating again and make the module healthier. Please refer to [2021 Maintenance plan](https://github.com/hyochan/react-native-iap/issues/1241) and share with us how you or your organization is using it. Happy new year 🎉
-
-  - The sample code is out in [crossplatformkorea/CPK/pull/12](https://github.com/crossplatformkorea/CPK/pull/12). More information in [#1241 commment](https://github.com/hyochan/react-native-iap/issues/1241#issuecomment-798540785).
 
 ## Configuration of Play Store & App Store Connect
 
@@ -62,18 +49,12 @@ Follow [this guide](./IapExample/README.md) to get the example running.
 
 ## Past Sponsors
 
-<a href="https://namiml.com"><img src="https://github.com/hyochan/react-native-iap/assets/27461460/89d71f61-bb73-400a-83bd-fe0f96eb726e" width="280"/></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://www.revenuecat.com"><img src="https://github.com/hyochan/react-native-iap/assets/27461460/1e387a47-afe0-4b85-ad78-1064ca6623fa" width="200"/></a>
+<a href="https://namiml.com"><img src="https://github.com/hyochan/react-native-iap/assets/27461460/89d71f61-bb73-400a-83bd-fe0f96eb726e" width="280"/></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://www.revenuecat.com"><img src="https://github.com/hyochan/react-native-iap/assets/27461460/1e387a47-afe0-4b85-ad78-1064ca6623fa" width="100"/></a>
 
 Support this project by becoming a sponsor. Your logo will show up here with
 a link to your website. [Buy me a coffee](https://www.buymeacoffee.com/hyochan) or
 [Become a sponsor](https://opencollective.com/react-native-iap#sponsor).
 <a href="https://opencollective.com/react-native-iap#sponsors" target="_blank"><img src="https://opencollective.com/react-native-iap/sponsors.svg?width=890" /></a>
-
-## Need Help Implementing/Debugging/Testing your IAP project?
-
-Please take a look at [iap.dev/consulting](https://iap.dev/consulting). At iap.dev, we offer IAP consulting services for all platforms. Please [Contact Us](https://console.iap.dev/contact-us).
-
-Note: This service is not affiliated with [hyochan](https://github.com/hyochan). It was created by [andresesfm](https://github.com/andresesfm) who has contributed and provided support for this project
 
 ### Backers
 

--- a/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
@@ -283,11 +283,16 @@ class RNIapModule(
                     skus[skuDetails.productId] = skuDetails
 
                     val item = Arguments.createMap()
+                    // Add both field names for compatibility
                     item.putString("productId", skuDetails.productId)
+                    item.putString("id", skuDetails.productId)
                     item.putString("title", skuDetails.title)
                     item.putString("description", skuDetails.description)
                     item.putString("productType", skuDetails.productType)
+                    item.putString("type", skuDetails.productType)
                     item.putString("name", skuDetails.name)
+                    item.putString("displayName", skuDetails.name)
+                    item.putString("platform", "android")
 
                     skuDetails.oneTimePurchaseOfferDetails?.let {
                         val oneTimePurchaseOfferDetails =
@@ -297,6 +302,9 @@ class RNIapModule(
                                 putString("priceAmountMicros", it.priceAmountMicros.toString())
                             }
                         item.putMap("oneTimePurchaseOfferDetails", oneTimePurchaseOfferDetails)
+                        // Add expo-iap compatible fields
+                        item.putString("currency", it.priceCurrencyCode)
+                        item.putString("displayPrice", it.formattedPrice)
                     }
 
                     skuDetails.subscriptionOfferDetails?.let {
@@ -378,15 +386,19 @@ class RNIapModule(
                 if (!isValidResult(billingResult, promise)) return@queryPurchasesAsync
                 purchases?.forEach { purchase ->
                     val item = WritableNativeMap()
-                    item.putString("productId", purchase.products[0]) // kept for convenience/backward-compatibility. productIds has the complete list
+                    // Add both field names for compatibility
+                    item.putString("productId", purchase.products[0]) // kept for convenience/backward-compatibility
+                    item.putString("id", purchase.products[0])
                     val products = Arguments.createArray()
                     purchase.products.forEach { products.pushString(it) }
                     item.putArray("productIds", products)
+                    item.putArray("ids", products)
                     item.putString("transactionId", purchase.orderId)
                     item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
                     item.putString("transactionReceipt", purchase.originalJson)
                     item.putString("orderId", purchase.orderId)
                     item.putString("purchaseToken", purchase.purchaseToken)
+                    item.putString("purchaseTokenAndroid", purchase.purchaseToken)
                     item.putString("developerPayloadAndroid", purchase.developerPayload)
                     item.putString("signatureAndroid", purchase.signature)
                     item.putInt("purchaseStateAndroid", purchase.purchaseState)
@@ -403,6 +415,7 @@ class RNIapModule(
                     if (type == BillingClient.ProductType.SUBS) {
                         item.putBoolean("autoRenewingAndroid", purchase.isAutoRenewing)
                     }
+                    item.putString("platform", "android")
                     items.pushMap(item)
                 }
                 promise.safeResolve(items)
@@ -432,16 +445,21 @@ class RNIapModule(
                 val items = Arguments.createArray()
                 purchaseHistoryRecordList?.forEach { purchase ->
                     val item = Arguments.createMap()
+                    // Add both field names for compatibility
                     item.putString("productId", purchase.products[0])
+                    item.putString("id", purchase.products[0])
                     val products = Arguments.createArray()
                     purchase.products.forEach { products.pushString(it) }
                     item.putArray("productIds", products)
+                    item.putArray("ids", products)
                     item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
                     item.putString("transactionReceipt", purchase.originalJson)
                     item.putString("purchaseToken", purchase.purchaseToken)
+                    item.putString("purchaseTokenAndroid", purchase.purchaseToken)
                     item.putString("dataAndroid", purchase.originalJson)
                     item.putString("signatureAndroid", purchase.signature)
                     item.putString("developerPayload", purchase.developerPayload.orEmpty())
+                    item.putString("platform", "android")
                     items.pushMap(item)
                 }
                 promise.safeResolve(items)
@@ -598,6 +616,7 @@ class RNIapModule(
                 map.putString("code", errorData.code)
                 map.putString("message", errorData.message)
                 map.putString("purchaseToken", purchaseToken)
+                map.putString("purchaseTokenAndroid", purchaseToken)
                 promise.safeResolve(map)
             }
         }
@@ -623,14 +642,18 @@ class RNIapModule(
             val promiseItems: WritableArray = Arguments.createArray()
             purchases.forEach { purchase ->
                 val item = Arguments.createMap()
+                // Add both productId (for backward compatibility) and id (for expo-iap compatibility)
                 item.putString("productId", purchase.products[0])
+                item.putString("id", purchase.products[0])
                 val products = Arguments.createArray()
                 purchase.products.forEach { products.pushString(it) }
                 item.putArray("productIds", products)
+                item.putArray("ids", products)
                 item.putString("transactionId", purchase.orderId)
                 item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
                 item.putString("transactionReceipt", purchase.originalJson)
                 item.putString("purchaseToken", purchase.purchaseToken)
+                item.putString("purchaseTokenAndroid", purchase.purchaseToken)
                 item.putString("dataAndroid", purchase.originalJson)
                 item.putString("signatureAndroid", purchase.signature)
                 item.putBoolean("autoRenewingAndroid", purchase.isAutoRenewing)
@@ -649,6 +672,7 @@ class RNIapModule(
                         accountIdentifiers.obfuscatedProfileId,
                     )
                 }
+                item.putString("platform", "android")
                 promiseItems.pushMap(item.copy())
                 sendEvent(reactContext, "purchase-updated", item)
             }

--- a/docs/docs/migrate_to_13.0.0.mdx
+++ b/docs/docs/migrate_to_13.0.0.mdx
@@ -1,0 +1,136 @@
+---
+title: Migrating to 13.0.0
+sidebar_label: Migrating to 13.0.0
+---
+
+import AdFitTopFixed from "@site/src/uis/AdFitTopFixed";
+
+<AdFitTopFixed />
+
+# Migrating to 13.0.0
+
+This version brings react-native-iap in line with expo-iap v2.5.2, adding several new features and field names for better compatibility.
+
+## New Features
+
+### iOS Receipt Validation
+
+Added new methods for iOS receipt validation:
+
+```ts
+import { getReceiptIos, validateReceiptIos } from 'react-native-iap';
+
+// Get the receipt data
+const receipt = await getReceiptIos();
+
+// Validate the receipt with Apple's servers
+const validationResult = await validateReceiptIos({
+  'receipt-data': receipt,
+  password: 'your-shared-secret', // Only for auto-renewable subscriptions
+}, true); // isTest: true for sandbox, false for production
+```
+
+### Enhanced useIAP Hook
+
+The `useIAP` hook now supports callbacks and additional methods:
+
+```ts
+const { 
+  restorePurchases,
+  validateReceipt,
+} = useIAP({
+  onPurchaseSuccess: (purchase) => {
+    console.log('Purchase successful:', purchase);
+  },
+  onPurchaseError: (error) => {
+    console.error('Purchase failed:', error);
+  },
+  onRestoreSuccess: (purchases) => {
+    console.log('Restore successful:', purchases);
+  },
+  onRestoreError: (error) => {
+    console.error('Restore failed:', error);
+  },
+});
+```
+
+### iOS 16+ Transaction Fields
+
+New transaction fields for iOS 16 and 17:
+
+- `jwsRepresentationIos`: JWS representation of the transaction (StoreKit 2)
+- `environmentIos`: Transaction environment (Production/Sandbox)
+- `storefrontCountryCodeIos`: Storefront country code
+- `reasonIos`: Transaction reason (iOS 16.4+)
+- `offerIos`: Promotional offer information (iOS 17.2+)
+- `priceIos`: Transaction price (iOS 17.2+)
+- `currencyIos`: Transaction currency (iOS 17.2+)
+
+## Field Name Compatibility
+
+To ensure compatibility with expo-iap, the following field names are now available alongside the existing ones:
+
+### Product Fields
+
+| Original Field | New Compatible Field |
+|---------------|---------------------|
+| `productId` | `id` |
+| `productIds` | `ids` |
+| `productType` | `type` |
+| `name` | `displayName` |
+
+### Purchase Fields
+
+| Original Field | New Compatible Field |
+|---------------|---------------------|
+| `productId` | `id` |
+| `productIds` | `ids` |
+| `purchaseToken` | `purchaseTokenAndroid` |
+
+All responses now include a `platform` field set to either `"ios"` or `"android"`.
+
+### Android-specific Fields
+
+For Android products with one-time purchase details:
+- `currency`: Currency code from `oneTimePurchaseOfferDetails`
+- `displayPrice`: Formatted price from `oneTimePurchaseOfferDetails`
+
+## Type Updates
+
+New discriminated union types are available for better type safety:
+
+```ts
+import { ProductWithPlatform, PurchaseWithPlatform } from 'react-native-iap';
+
+// These types include platform discrimination
+const product: ProductWithPlatform = {
+  platform: 'ios',
+  productId: 'com.example.product',
+  // ... iOS-specific fields
+};
+
+const purchase: PurchaseWithPlatform = {
+  platform: 'android',
+  productId: 'com.example.product',
+  purchaseTokenAndroid: '...',
+  // ... Android-specific fields
+};
+```
+
+## Backward Compatibility
+
+All original field names are maintained for backward compatibility. Your existing code will continue to work without changes. The new field names are added alongside the existing ones to provide compatibility with expo-iap.
+
+## Example Migration
+
+If you're migrating from expo-iap to react-native-iap, you can now use the same field names:
+
+```ts
+// Works with both expo-iap and react-native-iap 13.0.0+
+products.map(product => ({
+  id: product.id,              // Same as productId
+  type: product.type,          // Same as productType
+  displayName: product.displayName, // Same as name
+  platform: product.platform,  // 'ios' or 'android'
+}));
+```

--- a/ios/IapSerializationUtils.swift
+++ b/ios/IapSerializationUtils.swift
@@ -209,6 +209,42 @@ func serialize(_ t: Transaction) -> [String: Any?] {
         result["appTransactionID"] = t.appTransactionID
     }
     #endif
+    
+    // Additional fields from expo-iap
+    if #available(iOS 16.0, tvOS 16.0, *) {
+        result["environmentIos"] = t.environment.rawValue
+    }
+    
+    if #available(iOS 17.0, tvOS 17.0, *) {
+        result["storefrontCountryCodeIos"] = t.storefront.countryCode
+        result["reasonIos"] = t.reason.rawValue
+    }
+    
+    if #available(iOS 17.2, tvOS 17.2, *) {
+        if let offer = t.offer {
+            result["offerIos"] = [
+                "id": offer.id,
+                "type": offer.type.rawValue,
+                "paymentMode": offer.paymentMode?.rawValue ?? ""
+            ]
+        }
+    }
+    
+    // Extract price and currency from JSON representation
+    if #available(iOS 15.4, tvOS 15.4, *) {
+        do {
+            if let jsonObj = try JSONSerialization.jsonObject(with: t.jsonRepresentation) as? [String: Any] {
+                if let price = jsonObj["price"] as? NSNumber {
+                    result["priceIos"] = price.doubleValue
+                }
+                if let currency = jsonObj["currency"] as? String {
+                    result["currencyIos"] = currency
+                }
+            }
+        } catch {
+            // Ignore JSON parsing errors
+        }
+    }
 
     return result
 }
@@ -216,6 +252,7 @@ func serialize(_ t: Transaction) -> [String: Any?] {
 func serialize(_ t: Transaction, _ v: VerificationResult<Transaction>) -> [String: Any?] {
     var transaction = serialize(t)
     transaction.updateValue(v.jwsRepresentation, forKey: "verificationResult")
+    transaction.updateValue(v.jwsRepresentation, forKey: "jwsRepresentationIos")
     return transaction
 }
 @available(iOS 15.0, tvOS 15.0, *)

--- a/ios/RNIapIosSk2.m
+++ b/ios/RNIapIosSk2.m
@@ -99,5 +99,24 @@ RCT_EXTERN_METHOD(beginRefundRequest:
 RCT_EXTERN_METHOD(getStorefront:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getReceiptData:
+                  (RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isTransactionVerified:
+                  (NSString*)sku
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getTransactionJws:
+                  (NSString*)sku
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(validateReceiptIos:
+                  (NSString*)sku
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 @end
 #endif

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -443,6 +443,8 @@ class RNIapIosSk2iOS15: Sk2Delegate {
     private let _hasListenersQueue = DispatchQueue(label: "com.dooboolab.rniap.hasListenersQueue", attributes: .concurrent)
     private var transactions: [String: Transaction]
     private var updateListenerTask: Task<Void, Error>?
+    private var subscriptionPollingTask: Task<Void, Never>?
+    private var pollingSkus: Set<String> = []
     fileprivate var sendEvent: ((String?, Any?) -> Void)?
     var hasListeners: Bool {
         get {
@@ -990,8 +992,17 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                 return
             }
 
+            // Get all subscription SKUs before showing the management UI
+            let subscriptionSkus = await getAllSubscriptionProductIds()
+            self.pollingSkus = Set(subscriptionSkus)
+
             do {
                 try await AppStore.showManageSubscriptions(in: scene)
+                
+                // Start polling for subscription status changes after UI is shown
+                if !self.pollingSkus.isEmpty {
+                    self.pollForSubscriptionStatusChanges()
+                }
             } catch {
                 print("Error:(error)")
             }
@@ -1070,6 +1081,187 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         Task {
             let storefront = await Storefront.current
             resolve(storefront?.countryCode)
+        }
+    }
+    
+    // MARK: - New methods from expo-iap
+    
+    public func getReceiptData(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        if let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
+           FileManager.default.fileExists(atPath: appStoreReceiptURL.path) {
+            do {
+                let receiptData = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+                let receiptString = receiptData.base64EncodedString(options: [])
+                resolve(receiptString)
+            } catch {
+                reject(IapErrors.E_RECEIPT_FAILED.rawValue, "Error reading receipt data: \(error.localizedDescription)", error)
+            }
+        } else {
+            reject(IapErrors.E_RECEIPT_FAILED.rawValue, "App Store receipt not found", nil)
+        }
+    }
+    
+    public func isTransactionVerified(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Task {
+            if let product = await productStore.getProduct(productID: sku),
+               let result = await product.latestTransaction {
+                do {
+                    // If this doesn't throw, the transaction is verified
+                    _ = try checkVerified(result)
+                    resolve(true)
+                } catch {
+                    resolve(false)
+                }
+            } else {
+                resolve(false)
+            }
+        }
+    }
+    
+    public func getTransactionJws(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Task {
+            if let product = await productStore.getProduct(productID: sku),
+               let result = await product.latestTransaction {
+                resolve(result.jwsRepresentation)
+            } else {
+                reject(IapErrors.E_DEVELOPER_ERROR.rawValue, "Can't find transaction for sku \(sku)", nil)
+            }
+        }
+    }
+    
+    public func validateReceiptIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Task {
+            // Get receipt data
+            var receiptData: String = ""
+            if let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
+               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) {
+                do {
+                    let data = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+                    receiptData = data.base64EncodedString(options: [])
+                } catch {
+                    // Continue with validation even if receipt retrieval fails
+                }
+            }
+            
+            var isValid = false
+            var jwsRepresentation: String? = nil
+            var latestTransaction: [String: Any?]? = nil
+            
+            // Get JWS representation and verify transaction
+            if let product = await productStore.getProduct(productID: sku),
+               let result = await product.latestTransaction {
+                jwsRepresentation = result.jwsRepresentation
+                
+                do {
+                    // If this doesn't throw, the transaction is verified
+                    let transaction = try checkVerified(result)
+                    isValid = true
+                    latestTransaction = serialize(transaction, result)
+                } catch {
+                    isValid = false
+                }
+            }
+            
+            let response: [String: Any] = [
+                "isValid": isValid,
+                "receiptData": receiptData,
+                "jwsRepresentation": jwsRepresentation ?? "",
+                "latestTransaction": latestTransaction as Any
+            ]
+            
+            resolve(response)
+        }
+    }
+    
+    // MARK: - Subscription polling helpers
+    
+    private func getAllSubscriptionProductIds() async -> [String] {
+        let products = await productStore.getAllProducts()
+        return products.compactMap { product in
+            if product.subscription != nil {
+                return product.id
+            }
+            return nil
+        }
+    }
+    
+    private func pollForSubscriptionStatusChanges() {
+        subscriptionPollingTask?.cancel()
+        subscriptionPollingTask = Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 seconds
+            
+            var previousStatuses: [String: Bool] = [:] // Track auto-renewal state with Bool
+            
+            for sku in self.pollingSkus {
+                guard let product = await self.productStore.getProduct(productID: sku),
+                      let status = try? await product.subscription?.status.first else { continue }
+                
+                // Track willAutoRenew as a bool value
+                var willAutoRenew = false
+                if case .verified(let info) = status.renewalInfo {
+                    willAutoRenew = info.willAutoRenew
+                }
+                previousStatuses[sku] = willAutoRenew
+            }
+
+            for _ in 1...5 {
+                try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+                if Task.isCancelled {
+                    return
+                }
+                
+                for sku in self.pollingSkus {
+                    guard let product = await self.productStore.getProduct(productID: sku),
+                          let status = try? await product.subscription?.status.first,
+                          let result = await product.latestTransaction else { continue }
+                    // Try to verify the transaction
+                    let transaction: Transaction
+                    do {
+                        transaction = try checkVerified(result)
+                    } catch {
+                        continue // Skip if verification fails
+                    }
+                    
+                    // Track current auto-renewal state
+                    var currentWillAutoRenew = false
+                    if case .verified(let info) = status.renewalInfo {
+                        currentWillAutoRenew = info.willAutoRenew
+                    }
+                    
+                    // Compare with previous state
+                    if let previousWillAutoRenew = previousStatuses[sku], 
+                       previousWillAutoRenew != currentWillAutoRenew {
+                        
+                        // Use the jwsRepresentation when serializing the transaction
+                        var purchaseMap = serialize(transaction, result)
+                        
+                        if case .verified(let renewalInfo) = status.renewalInfo {
+                            if let renewalInfoDict = serialize(renewalInfo) {
+                                purchaseMap["renewalInfo"] = renewalInfoDict
+                            }
+                        }
+                        
+                        self.sendEvent?("purchase-updated", purchaseMap)
+                        previousStatuses[sku] = currentWillAutoRenew
+                    }
+                }
+            }
+            self.pollingSkus.removeAll()
         }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,5 @@ export * from './hooks/useIAP';
 export * from './hooks/withIAPContext';
 export * from './purchaseError';
 export * from './modules';
+export * from './utils/errorMapping';
+export * from './utils/typeGuards';

--- a/src/modules/iosSk2.ts
+++ b/src/modules/iosSk2.ts
@@ -60,6 +60,15 @@ export interface IosModulePropsSk2 extends NativeModuleProps {
   disable: () => Promise<null>;
   beginRefundRequest: (sku: string) => Promise<RefundRequestStatus>;
   getStorefront: getStorefront;
+  getReceiptData: () => Promise<string>;
+  isTransactionVerified: (sku: string) => Promise<boolean>;
+  getTransactionJws: (sku: string) => Promise<string>;
+  validateReceiptIos: (sku: string) => Promise<{
+    isValid: boolean;
+    receiptData: string;
+    jwsRepresentation: string;
+    latestTransaction?: TransactionSk2;
+  }>;
 }
 
 /**
@@ -111,3 +120,63 @@ export const showManageSubscriptions = (): Promise<null> =>
 export const finishTransaction = (
   transactionIdentifier: string,
 ): Promise<Boolean> => RNIapIosSk2.finishTransaction(transactionIdentifier);
+
+/**
+ * Get the receipt data from the iOS device.
+ * This returns the base64 encoded receipt data which can be sent to your server
+ * for verification with Apple's server.
+ *
+ * NOTE: For proper security, always verify receipts on your server using
+ * Apple's verifyReceipt endpoint, not directly from the app.
+ *
+ * @returns {Promise<string>} Base64 encoded receipt data
+ */
+export const getReceiptIos = (): Promise<string> =>
+  RNIapIosSk2.getReceiptData();
+
+/**
+ * Check if a transaction is verified through StoreKit 2.
+ * StoreKit 2 performs local verification of transaction JWS signatures.
+ *
+ * @param {string} sku The product's SKU (on iOS)
+ * @returns {Promise<boolean>} True if the transaction is verified
+ */
+export const isTransactionVerified = (sku: string): Promise<boolean> =>
+  RNIapIosSk2.isTransactionVerified(sku);
+
+/**
+ * Get the JWS representation of a purchase for server-side verification.
+ * The JWS (JSON Web Signature) can be verified on your server using Apple's public keys.
+ *
+ * @param {string} sku The product's SKU (on iOS)
+ * @returns {Promise<string>} JWS representation of the transaction
+ */
+export const getTransactionJws = (sku: string): Promise<string> =>
+  RNIapIosSk2.getTransactionJws(sku);
+
+/**
+ * Validate receipt for iOS using StoreKit 2's built-in verification.
+ * Returns receipt data and verification information to help with server-side validation.
+ *
+ * NOTE: For proper security, Apple recommends verifying receipts on your server using
+ * the verifyReceipt endpoint rather than relying solely on client-side verification.
+ *
+ * @param {string} sku The product's SKU (on iOS)
+ * @returns {Promise<{
+ *   isValid: boolean;
+ *   receiptData: string;
+ *   jwsRepresentation: string;
+ *   latestTransaction?: TransactionSk2;
+ * }>}
+ */
+export const validateReceiptIos = async (
+  sku: string,
+): Promise<{
+  isValid: boolean;
+  receiptData: string;
+  jwsRepresentation: string;
+  latestTransaction?: TransactionSk2;
+}> => {
+  const result = await RNIapIosSk2.validateReceiptIos(sku);
+  return result;
+};

--- a/src/purchaseError.ts
+++ b/src/purchaseError.ts
@@ -16,7 +16,75 @@ export enum ErrorCode {
   E_DEFERRED_PAYMENT = 'E_DEFERRED_PAYMENT',
   E_INTERRUPTED = 'E_INTERRUPTED',
   E_IAP_NOT_AVAILABLE = 'E_IAP_NOT_AVAILABLE',
+  E_PURCHASE_ERROR = 'E_PURCHASE_ERROR',
+  E_SYNC_ERROR = 'E_SYNC_ERROR',
+  E_TRANSACTION_VALIDATION_FAILED = 'E_TRANSACTION_VALIDATION_FAILED',
+  E_ACTIVITY_UNAVAILABLE = 'E_ACTIVITY_UNAVAILABLE',
+  E_ALREADY_PREPARED = 'E_ALREADY_PREPARED',
+  E_PENDING = 'E_PENDING',
+  E_CONNECTION_CLOSED = 'E_CONNECTION_CLOSED',
 }
+
+/**
+ * Platform-specific error code mappings
+ * Maps ErrorCode enum values to platform-specific integer codes
+ */
+export const ErrorCodeMapping = {
+  ios: {
+    [ErrorCode.E_UNKNOWN]: 0,
+    [ErrorCode.E_SERVICE_ERROR]: 1,
+    [ErrorCode.E_USER_CANCELLED]: 2,
+    [ErrorCode.E_USER_ERROR]: 3,
+    [ErrorCode.E_ITEM_UNAVAILABLE]: 4,
+    [ErrorCode.E_REMOTE_ERROR]: 5,
+    [ErrorCode.E_NETWORK_ERROR]: 6,
+    [ErrorCode.E_RECEIPT_FAILED]: 7,
+    [ErrorCode.E_RECEIPT_FINISHED_FAILED]: 8,
+    [ErrorCode.E_DEVELOPER_ERROR]: 9,
+    [ErrorCode.E_PURCHASE_ERROR]: 10,
+    [ErrorCode.E_SYNC_ERROR]: 11,
+    [ErrorCode.E_DEFERRED_PAYMENT]: 12,
+    [ErrorCode.E_TRANSACTION_VALIDATION_FAILED]: 13,
+    [ErrorCode.E_NOT_PREPARED]: 14,
+    [ErrorCode.E_NOT_ENDED]: 15,
+    [ErrorCode.E_ALREADY_OWNED]: 16,
+    [ErrorCode.E_BILLING_RESPONSE_JSON_PARSE_ERROR]: 17,
+    [ErrorCode.E_INTERRUPTED]: 18,
+    [ErrorCode.E_IAP_NOT_AVAILABLE]: 19,
+    [ErrorCode.E_ACTIVITY_UNAVAILABLE]: 20,
+    [ErrorCode.E_ALREADY_PREPARED]: 21,
+    [ErrorCode.E_PENDING]: 22,
+    [ErrorCode.E_CONNECTION_CLOSED]: 23,
+  },
+  android: {
+    [ErrorCode.E_UNKNOWN]: 'E_UNKNOWN',
+    [ErrorCode.E_USER_CANCELLED]: 'E_USER_CANCELLED',
+    [ErrorCode.E_USER_ERROR]: 'E_USER_ERROR',
+    [ErrorCode.E_ITEM_UNAVAILABLE]: 'E_ITEM_UNAVAILABLE',
+    [ErrorCode.E_REMOTE_ERROR]: 'E_REMOTE_ERROR',
+    [ErrorCode.E_NETWORK_ERROR]: 'E_NETWORK_ERROR',
+    [ErrorCode.E_SERVICE_ERROR]: 'E_SERVICE_ERROR',
+    [ErrorCode.E_RECEIPT_FAILED]: 'E_RECEIPT_FAILED',
+    [ErrorCode.E_RECEIPT_FINISHED_FAILED]: 'E_RECEIPT_FINISHED_FAILED',
+    [ErrorCode.E_NOT_PREPARED]: 'E_NOT_PREPARED',
+    [ErrorCode.E_NOT_ENDED]: 'E_NOT_ENDED',
+    [ErrorCode.E_ALREADY_OWNED]: 'E_ALREADY_OWNED',
+    [ErrorCode.E_DEVELOPER_ERROR]: 'E_DEVELOPER_ERROR',
+    [ErrorCode.E_BILLING_RESPONSE_JSON_PARSE_ERROR]:
+      'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
+    [ErrorCode.E_DEFERRED_PAYMENT]: 'E_DEFERRED_PAYMENT',
+    [ErrorCode.E_INTERRUPTED]: 'E_INTERRUPTED',
+    [ErrorCode.E_IAP_NOT_AVAILABLE]: 'E_IAP_NOT_AVAILABLE',
+    [ErrorCode.E_PURCHASE_ERROR]: 'E_PURCHASE_ERROR',
+    [ErrorCode.E_SYNC_ERROR]: 'E_SYNC_ERROR',
+    [ErrorCode.E_TRANSACTION_VALIDATION_FAILED]:
+      'E_TRANSACTION_VALIDATION_FAILED',
+    [ErrorCode.E_ACTIVITY_UNAVAILABLE]: 'E_ACTIVITY_UNAVAILABLE',
+    [ErrorCode.E_ALREADY_PREPARED]: 'E_ALREADY_PREPARED',
+    [ErrorCode.E_PENDING]: 'E_PENDING',
+    [ErrorCode.E_CONNECTION_CLOSED]: 'E_CONNECTION_CLOSED',
+  },
+} as const;
 
 export class PurchaseError implements Error {
   constructor(
@@ -26,6 +94,7 @@ export class PurchaseError implements Error {
     public debugMessage?: string,
     public code?: ErrorCode,
     public productId?: string,
+    public platform?: 'ios' | 'android',
   ) {
     this.name = '[react-native-iap]: PurchaseError';
     this.message = message;
@@ -33,5 +102,95 @@ export class PurchaseError implements Error {
     this.debugMessage = debugMessage;
     this.code = code;
     this.productId = productId;
+    this.platform = platform;
+  }
+
+  /**
+   * Creates a PurchaseError from platform-specific error data
+   * @param errorData Raw error data from native modules
+   * @param platform Platform where the error occurred
+   * @returns Properly typed PurchaseError instance
+   */
+  static fromPlatformError(
+    errorData: any,
+    platform: 'ios' | 'android',
+  ): PurchaseError {
+    const errorCode = errorData.code
+      ? ErrorCodeUtils.fromPlatformCode(errorData.code, platform)
+      : ErrorCode.E_UNKNOWN;
+
+    return new PurchaseError(
+      '[react-native-iap]: PurchaseError',
+      errorData.message || 'Unknown error occurred',
+      errorData.responseCode,
+      errorData.debugMessage,
+      errorCode,
+      errorData.productId,
+      platform,
+    );
+  }
+
+  /**
+   * Gets the platform-specific error code for this error
+   * @returns Platform-specific error code
+   */
+  getPlatformCode(): string | number | undefined {
+    if (!this.code || !this.platform) return undefined;
+    return ErrorCodeUtils.toPlatformCode(this.code, this.platform);
   }
 }
+
+/**
+ * Utility functions for error code mapping and validation
+ */
+export const ErrorCodeUtils = {
+  /**
+   * Maps a platform-specific error code back to the standardized ErrorCode enum
+   * @param platformCode Platform-specific error code (string for Android, number for iOS)
+   * @param platform Target platform
+   * @returns Corresponding ErrorCode enum value or E_UNKNOWN if not found
+   */
+  fromPlatformCode: (
+    platformCode: string | number,
+    platform: 'ios' | 'android',
+  ): ErrorCode => {
+    const mapping = ErrorCodeMapping[platform];
+
+    for (const [errorCode, mappedCode] of Object.entries(mapping)) {
+      if (mappedCode === platformCode) {
+        return errorCode as ErrorCode;
+      }
+    }
+
+    return ErrorCode.E_UNKNOWN;
+  },
+
+  /**
+   * Maps an ErrorCode enum to platform-specific code
+   * @param errorCode ErrorCode enum value
+   * @param platform Target platform
+   * @returns Platform-specific error code
+   */
+  toPlatformCode: (
+    errorCode: ErrorCode,
+    platform: 'ios' | 'android',
+  ): string | number => {
+    return (
+      ErrorCodeMapping[platform][errorCode] ??
+      (platform === 'ios' ? 0 : 'E_UNKNOWN')
+    );
+  },
+
+  /**
+   * Checks if an error code is valid for the specified platform
+   * @param errorCode ErrorCode enum value
+   * @param platform Target platform
+   * @returns True if the error code is supported on the platform
+   */
+  isValidForPlatform: (
+    errorCode: ErrorCode,
+    platform: 'ios' | 'android',
+  ): boolean => {
+    return errorCode in ErrorCodeMapping[platform];
+  },
+};

--- a/src/types/appleSk2.ts
+++ b/src/types/appleSk2.ts
@@ -130,6 +130,18 @@ export type TransactionSk2 = {
   subscriptionGroupID: number;
   webOrderLineItemID: number;
   verificationResult?: string;
+  jwsRepresentationIos?: string;
+  environmentIos?: string; // iOS 16+
+  storefrontCountryCodeIos?: string; // iOS 17+
+  reasonIos?: string; // iOS 17+
+  offerIos?: {
+    // iOS 17.2+
+    id: string;
+    type: string;
+    paymentMode: string;
+  };
+  priceIos?: number; // iOS 15.4+
+  currencyIos?: string; // iOS 15.4+
 };
 
 export type TransactionError = PurchaseError;
@@ -178,6 +190,13 @@ export const transactionSk2ToPurchaseMap = ({
   appAccountToken,
   appTransactionID,
   jsonRepresentation,
+  jwsRepresentationIos,
+  environmentIos,
+  storefrontCountryCodeIos,
+  reasonIos,
+  offerIos,
+  priceIos,
+  currencyIos,
 }: TransactionSk2): Purchase => {
   let transactionReasonIOS;
   try {
@@ -202,6 +221,13 @@ export const transactionSk2ToPurchaseMap = ({
     appAccountToken: appAccountToken ?? '',
     appTransactionID: appTransactionID ?? '',
     transactionReasonIOS: transactionReasonIOS ?? '',
+    jwsRepresentationIos,
+    environmentIos,
+    storefrontCountryCodeIos,
+    reasonIos,
+    offerIos,
+    priceIos,
+    currencyIos,
   };
   return purchase;
 };

--- a/src/utils/errorMapping.ts
+++ b/src/utils/errorMapping.ts
@@ -1,0 +1,88 @@
+/**
+ * Error mapping utilities for react-native-iap
+ * Provides helper functions for handling platform-specific errors
+ */
+
+import {ErrorCode} from '../purchaseError';
+
+/**
+ * Checks if an error is a user cancellation
+ * @param error Error object or error code
+ * @returns True if the error represents user cancellation
+ */
+export function isUserCancelledError(error: any): boolean {
+  if (typeof error === 'string') {
+    return error === ErrorCode.E_USER_CANCELLED;
+  }
+
+  if (error && error.code) {
+    return error.code === ErrorCode.E_USER_CANCELLED;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if an error is related to network connectivity
+ * @param error Error object or error code
+ * @returns True if the error is network-related
+ */
+export function isNetworkError(error: any): boolean {
+  const networkErrors = [
+    ErrorCode.E_NETWORK_ERROR,
+    ErrorCode.E_REMOTE_ERROR,
+    ErrorCode.E_SERVICE_ERROR,
+  ];
+
+  const errorCode = typeof error === 'string' ? error : error?.code;
+  return networkErrors.includes(errorCode);
+}
+
+/**
+ * Checks if an error is recoverable (user can retry)
+ * @param error Error object or error code
+ * @returns True if the error is potentially recoverable
+ */
+export function isRecoverableError(error: any): boolean {
+  const recoverableErrors = [
+    ErrorCode.E_NETWORK_ERROR,
+    ErrorCode.E_REMOTE_ERROR,
+    ErrorCode.E_SERVICE_ERROR,
+    ErrorCode.E_INTERRUPTED,
+  ];
+
+  const errorCode = typeof error === 'string' ? error : error?.code;
+  return recoverableErrors.includes(errorCode);
+}
+
+/**
+ * Gets a user-friendly error message for display
+ * @param error Error object or error code
+ * @returns User-friendly error message
+ */
+export function getUserFriendlyErrorMessage(error: any): string {
+  const errorCode = typeof error === 'string' ? error : error?.code;
+
+  switch (errorCode) {
+    case ErrorCode.E_USER_CANCELLED:
+      return 'Purchase was cancelled by user';
+    case ErrorCode.E_NETWORK_ERROR:
+      return 'Network connection error. Please check your internet connection and try again.';
+    case ErrorCode.E_ITEM_UNAVAILABLE:
+      return 'This item is not available for purchase';
+    case ErrorCode.E_ALREADY_OWNED:
+      return 'You already own this item';
+    case ErrorCode.E_DEFERRED_PAYMENT:
+      return 'Payment is pending approval';
+    case ErrorCode.E_NOT_PREPARED:
+      return 'In-app purchase is not ready. Please try again later.';
+    case ErrorCode.E_SERVICE_ERROR:
+      return 'Store service error. Please try again later.';
+    case ErrorCode.E_TRANSACTION_VALIDATION_FAILED:
+      return 'Transaction could not be verified';
+    case ErrorCode.E_RECEIPT_FAILED:
+      return 'Receipt processing failed';
+    default:
+      return error?.message || 'An unexpected error occurred';
+  }
+}

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -1,0 +1,90 @@
+/**
+ * Type guard functions for react-native-iap
+ */
+
+import {Platform} from 'react-native';
+
+import type {
+  Product,
+  ProductPurchase,
+  ProductWithPlatform,
+  Purchase,
+  PurchaseWithPlatform,
+} from '../types';
+
+/**
+ * Type guard to check if a product is from iOS
+ */
+export function isProductIos(
+  product: Product | ProductWithPlatform,
+): product is Product & {platform?: 'ios'} {
+  return Platform.OS === 'ios' || (product as any).platform === 'ios';
+}
+
+/**
+ * Type guard to check if a product is from Android
+ */
+export function isProductAndroid(
+  product: Product | ProductWithPlatform,
+): product is Product & {platform?: 'android'} {
+  return Platform.OS === 'android' || (product as any).platform === 'android';
+}
+
+/**
+ * Type guard to check if a purchase is from iOS
+ */
+export function isPurchaseIos(
+  purchase: Purchase | PurchaseWithPlatform,
+): purchase is Purchase & {platform?: 'ios'} {
+  return Platform.OS === 'ios' || (purchase as any).platform === 'ios';
+}
+
+/**
+ * Type guard to check if a purchase is from Android
+ */
+export function isPurchaseAndroid(
+  purchase: Purchase | PurchaseWithPlatform,
+): purchase is Purchase & {platform?: 'android'} {
+  return Platform.OS === 'android' || (purchase as any).platform === 'android';
+}
+
+/**
+ * Type guard to check if a purchase is from Amazon
+ */
+export function isPurchaseAmazon(
+  purchase: Purchase | PurchaseWithPlatform,
+): purchase is Purchase & {platform?: 'amazon'} {
+  return (
+    (purchase as any).platform === 'amazon' || !!(purchase as any).userIdAmazon
+  );
+}
+
+/**
+ * Type guard to check if an item is a ProductPurchase
+ */
+export function isProductPurchase(item: unknown): item is ProductPurchase {
+  return (
+    item != null &&
+    typeof item === 'object' &&
+    'productId' in item &&
+    'transactionDate' in item &&
+    'transactionReceipt' in item
+  );
+}
+
+/**
+ * Helper to get the product ID from either field name
+ */
+export function getProductId(item: {productId?: string; id?: string}): string {
+  return item.productId || item.id || '';
+}
+
+/**
+ * Helper to get the display price from either field name
+ */
+export function getDisplayPrice(item: {
+  localizedPrice?: string;
+  displayPrice?: string;
+}): string {
+  return item.displayPrice || item.localizedPrice || '';
+}


### PR DESCRIPTION
### Key Features
  - ✅ iOS receipt validation: `getReceiptIos()`, `validateReceiptIos()`
  - ✅ StoreKit 2 transaction fields (iOS 16+/17+)
  - ✅ Enhanced `useIAP` hook with callbacks
  - ✅ expo-iap compatible field names (backward compatible)

  ### Field Compatibility
  Added new field names alongside existing ones:
  - `id` / `productId`
  - `type` / `productType`
  - `purchaseTokenAndroid` / `purchaseToken`

  **No breaking changes** - Existing code continues to work!

  ### Related
  - 📢 [Announcement](https://x.com/hyodotdev/status/1939420943665049961)
  - 🚀 [expo-iap](https://github.com/hyochan/expo-iap)