### PR TITLE
fix: Add missing iOS StoreKit2 method signatures

### DIFF
--- a/ios/RNIapIosSk2.m
+++ b/ios/RNIapIosSk2.m
@@ -104,16 +104,16 @@ RCT_EXTERN_METHOD(getAppTransaction:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getReceiptData:
+RCT_EXTERN_METHOD(getReceiptDataIos:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(isTransactionVerified:
+RCT_EXTERN_METHOD(isTransactionVerifiedIos:
                   (NSString*)sku
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getTransactionJws:
+RCT_EXTERN_METHOD(getTransactionJwsIos:
                   (NSString*)sku
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -112,6 +112,29 @@ protocol Sk2Delegate {
         reject: @escaping RCTPromiseRejectBlock
     )
 
+    func getReceiptDataIos(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    )
+
+    func isTransactionVerifiedIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    )
+
+    func getTransactionJwsIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    )
+
+    func validateReceiptIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    )
+
     func startObserving()
     func stopObserving()
 }
@@ -259,6 +282,37 @@ class DummySk2: Sk2Delegate {
 
     func getAppTransaction(
         _ resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        reject(errorCode, errorMessage, nil)
+    }
+
+    func getReceiptDataIos(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        reject(errorCode, errorMessage, nil)
+    }
+
+    func isTransactionVerifiedIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        reject(errorCode, errorMessage, nil)
+    }
+
+    func getTransactionJwsIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        reject(errorCode, errorMessage, nil)
+    }
+
+    func validateReceiptIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) {
         reject(errorCode, errorMessage, nil)
@@ -453,6 +507,37 @@ class RNIapIosSk2: RCTEventEmitter, Sk2Delegate {
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         delegate.getAppTransaction(resolve, reject: reject)
+    }
+
+    @objc public func getReceiptDataIos(
+        _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        delegate.getReceiptDataIos(resolve, reject: reject)
+    }
+
+    @objc public func isTransactionVerifiedIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        delegate.isTransactionVerifiedIos(sku, resolve: resolve, reject: reject)
+    }
+
+    @objc public func getTransactionJwsIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        delegate.getTransactionJwsIos(sku, resolve: resolve, reject: reject)
+    }
+
+    @objc public func validateReceiptIos(
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        delegate.validateReceiptIos(sku, resolve: resolve, reject: reject)
     }
 }
 
@@ -1148,7 +1233,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
 
     // MARK: - New methods from expo-iap
 
-    public func getReceiptData(
+    public func getReceiptDataIos(
         _ resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) {
@@ -1166,7 +1251,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    public func isTransactionVerified(
+    public func isTransactionVerifiedIos(
         _ sku: String,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
@@ -1187,7 +1272,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    public func getTransactionJws(
+    public func getTransactionJwsIos(
         _ sku: String,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock


### PR DESCRIPTION
## Summary
This PR fixes Objective-C bridge warnings for missing StoreKit2 method signatures in the RNIapIosSk2 module. The methods `getReceiptDataIos`, `isTransactionVerifiedIos`, `getTransactionJwsIos`, and `validateReceiptIos` were implemented in RNIapIosSk2iOS15 but missing from the protocol definition, causing runtime warnings about unavailable JS methods.

## Changes
- Added missing method signatures to Sk2Delegate protocol
- Implemented stub methods in DummySk2 class
- Added @objc bridge methods in main RNIapIosSk2 class
- Updated Objective-C extern method declarations

Closes #2976