### PR TITLE
fix: unwrap optional status type in iOS StoreKit2 logic

### DIFF
--- a/.github/workflows/ci-example-ios.yml
+++ b/.github/workflows/ci-example-ios.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Select Xcode version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: '16.3'
+          xcode-version: '16.4'
 
       - name: Restore buildcache
         uses: mikehardy/buildcache-action@1db83fb06b0da378aa7db7a1110923b904417cbc # v2.1.0

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -1360,7 +1360,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
 
                 // Track willAutoRenew as a bool value
                 var willAutoRenew = false
-                if case .verified(let info) = status.renewalInfo {
+                if case .verified(let info) = status?.renewalInfo {
                     willAutoRenew = info.willAutoRenew
                 }
                 previousStatuses[sku] = willAutoRenew
@@ -1386,7 +1386,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
 
                     // Track current auto-renewal state
                     var currentWillAutoRenew = false
-                    if case .verified(let info) = status.renewalInfo {
+                    if case .verified(let info) = status?.renewalInfo {
                         currentWillAutoRenew = info.willAutoRenew
                     }
 
@@ -1396,7 +1396,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                         // Use the jwsRepresentation when serializing the transaction
                         var purchaseMap = serialize(transaction, result)
 
-                        if case .verified(let renewalInfo) = status.renewalInfo {
+                        if case .verified(let renewalInfo) = status?.renewalInfo {
                             if let renewalInfoDict = serialize(renewalInfo) {
                                 purchaseMap["renewalInfo"] = renewalInfoDict
                             }


### PR DESCRIPTION
This fixes the following Swift build error when attempting to build the package with Xcode 16.4 (16F6) for iOS 18.6 (22G86):

```
Value of optional type 'Product.SubscriptionInfo.Status?' must be unwrapped to refer to member 'renewalInfo' of wrapped base type 'Product.SubscriptionInfo.Status'
```