### PR TITLE
chore: align openiap deps

### DIFF
--- a/NitroIap.podspec
+++ b/NitroIap.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'
   # OpenIAP Apple for StoreKit 2 integration
-  s.dependency 'openiap', '1.1.9'
+  s.dependency 'openiap', '1.1.12'
 
   install_modules_dependencies(s)
 end

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add the OpenIAP Google library to your `android/app/build.gradle` dependencies:
 
 ```gradle
 dependencies {
-    implementation "io.github.hyochan.openiap:openiap-google:1.1.0"
+    implementation "io.github.hyochan.openiap:openiap-google:1.1.10"
 }
 ```
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -156,8 +156,8 @@ dependencies {
   // Kotlin coroutines
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
 
-  // OpenIAP Google (v1.1.0)
-  implementation 'io.github.hyochan.openiap:openiap-google:1.1.0'
+  // OpenIAP Google (v1.1.10)
+  implementation 'io.github.hyochan.openiap:openiap-google:1.1.10'
 }
 
 configurations.all {

--- a/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -4,15 +4,15 @@ import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
 import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.Promise
-import dev.hyo.openiap.OpenIapError
+import dev.hyo.openiap.OpenIapError as OpenIAPError
 import dev.hyo.openiap.OpenIapModule
 import dev.hyo.openiap.listener.OpenIapPurchaseErrorListener
 import dev.hyo.openiap.listener.OpenIapPurchaseUpdateListener
+import dev.hyo.openiap.models.DeepLinkOptions
 import dev.hyo.openiap.models.OpenIapProduct
 import dev.hyo.openiap.models.OpenIapPurchase
-import dev.hyo.openiap.models.DeepLinkOptions
 import dev.hyo.openiap.models.ProductRequest
-import dev.hyo.openiap.models.RequestPurchaseAndroidProps
+import dev.hyo.openiap.models.OpenIapRequestPurchaseProps
 import dev.hyo.openiap.models.OpenIapSerialization
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -68,8 +68,8 @@ class HybridRnIap : HybridRnIapSpec() {
                         .onFailure { Log.e(TAG, "Failed to forward purchase update", it) }
                 })
                 openIap.addPurchaseErrorListener(OpenIapPurchaseErrorListener { e ->
-                    val code = OpenIapError.toCode(e)
-                    val message = e.message ?: OpenIapError.defaultMessage(code)
+                    val code = OpenIAPError.toCode(e)
+                    val message = e.message ?: OpenIAPError.defaultMessage(code)
                     runCatching {
                         sendPurchaseError(
                             NitroPurchaseResult(
@@ -88,11 +88,17 @@ class HybridRnIap : HybridRnIapSpec() {
             val deferred = initDeferred!!
             try {
                 val ok = runCatching { openIap.initConnection() }.getOrElse { err ->
-                    val error = OpenIapError.InitConnection(err.message ?: "Failed to initialize connection")
-                    throw Exception(toErrorJson(error))
+                    val error = OpenIAPError.InitConnection()
+                    throw Exception(
+                        toErrorJson(
+                            error = error,
+                            debugMessage = err.message,
+                            messageOverride = err.message
+                        )
+                    )
                 }
                 if (!ok) {
-                    val error = OpenIapError.InitConnection("Failed to initialize connection")
+                    val error = OpenIAPError.InitConnection()
                     throw Exception(toErrorJson(error))
                 }
                 isInitialized = true
@@ -125,7 +131,7 @@ class HybridRnIap : HybridRnIapSpec() {
             Log.d(TAG, "fetchProducts (OpenIAP) skus=${skus.joinToString()} type=$type")
 
             if (skus.isEmpty()) {
-                throw Exception(toErrorJson(OpenIapError.EmptySkuList))
+                throw Exception(toErrorJson(OpenIAPError.EmptySkuList))
             }
 
             initConnection().await()
@@ -147,12 +153,12 @@ class HybridRnIap : HybridRnIapSpec() {
 
             val androidRequest = request.android ?: run {
                 // Programming error: no Android params provided
-                sendPurchaseError(toErrorResult(OpenIapError.DeveloperError))
+                sendPurchaseError(toErrorResult(OpenIAPError.DeveloperError))
                 return@async defaultResult
             }
 
             if (androidRequest.skus.isEmpty()) {
-                sendPurchaseError(toErrorResult(OpenIapError.EmptySkuList))
+                sendPurchaseError(toErrorResult(OpenIAPError.EmptySkuList))
                 return@async defaultResult
             }
 
@@ -162,14 +168,14 @@ class HybridRnIap : HybridRnIapSpec() {
 
                 val missing = androidRequest.skus.firstOrNull { !productTypeBySku.containsKey(it) }
                 if (missing != null) {
-                    sendPurchaseError(toErrorResult(OpenIapError.SkuNotFound(missing), missing))
+                    sendPurchaseError(toErrorResult(OpenIAPError.SkuNotFound(missing), missing))
                     return@async defaultResult
                 }
                 val typeStr = androidRequest.skus.firstOrNull()?.let { productTypeBySku[it] } ?: "inapp"
                 val typeEnum = ProductRequest.ProductRequestType.fromString(typeStr)
 
                 val result = openIap.requestPurchase(
-                    RequestPurchaseAndroidProps(
+                    OpenIapRequestPurchaseProps(
                         skus = androidRequest.skus.toList(),
                         obfuscatedAccountIdAndroid = androidRequest.obfuscatedAccountIdAndroid,
                         obfuscatedProfileIdAndroid = androidRequest.obfuscatedProfileIdAndroid,
@@ -185,7 +191,13 @@ class HybridRnIap : HybridRnIapSpec() {
 
                 defaultResult
             } catch (e: Exception) {
-                sendPurchaseError(toErrorResult(OpenIapError.PurchaseFailed(e.message ?: "Purchase failed")))
+                sendPurchaseError(
+                    toErrorResult(
+                        error = OpenIAPError.PurchaseFailed(),
+                        debugMessage = e.message,
+                        messageOverride = e.message
+                    )
+                )
                 defaultResult
             }
         }
@@ -220,7 +232,7 @@ class HybridRnIap : HybridRnIapSpec() {
                     NitroPurchaseResult(
                         responseCode = -1.0,
                         debugMessage = "Missing purchaseToken",
-                        code = OpenIapError.toCode(OpenIapError.DeveloperError),
+                        code = OpenIAPError.toCode(OpenIAPError.DeveloperError),
                         message = "Missing purchaseToken",
                         purchaseToken = null
                     )
@@ -231,13 +243,13 @@ class HybridRnIap : HybridRnIapSpec() {
             try {
                 initConnection().await()
             } catch (e: Exception) {
-                val err = OpenIapError.InitConnection(e.message ?: "Failed to initialize connection")
+                val err = OpenIAPError.InitConnection()
                 return@async Variant_Boolean_NitroPurchaseResult.Second(
                     NitroPurchaseResult(
                         responseCode = -1.0,
                         debugMessage = e.message,
-                        code = OpenIapError.toCode(err),
-                        message = err.message,
+                        code = OpenIAPError.toCode(err),
+                        message = e.message?.takeIf { it.isNotBlank() } ?: err.message,
                         purchaseToken = purchaseToken
                     )
                 )
@@ -259,13 +271,13 @@ class HybridRnIap : HybridRnIapSpec() {
                     )
                 )
             } catch (e: Exception) {
-                val err = OpenIapError.BillingError(e.message ?: "Service error")
+                val err = OpenIAPError.BillingError()
                 Variant_Boolean_NitroPurchaseResult.Second(
                     NitroPurchaseResult(
                         responseCode = -1.0,
                         debugMessage = e.message,
-                        code = OpenIapError.toCode(err),
-                        message = err.message,
+                        code = OpenIAPError.toCode(err),
+                        message = e.message?.takeIf { it.isNotBlank() } ?: err.message,
                         purchaseToken = purchaseToken
                     )
                 )
@@ -361,7 +373,7 @@ class HybridRnIap : HybridRnIapSpec() {
         var subscriptionPeriodAndroid: String? = null
         var freeTrialPeriodAndroid: String? = null
 
-        if (product.type == OpenIapProduct.ProductType.INAPP) {
+        if (product.type == OpenIapProduct.ProductType.InApp) {
             product.oneTimePurchaseOfferDetailsAndroid?.let { otp ->
                 originalPriceAndroid = otp.formattedPrice
                 // priceAmountMicros is a string; parse to number if possible
@@ -433,8 +445,8 @@ class HybridRnIap : HybridRnIapSpec() {
     private fun convertToNitroPurchase(purchase: OpenIapPurchase): NitroPurchase {
         // Map OpenIAP purchase state back to legacy numeric Android state for compatibility
         val purchaseStateAndroidNumeric = when (purchase.purchaseState) {
-            OpenIapPurchase.PurchaseState.PURCHASED -> 1.0
-            OpenIapPurchase.PurchaseState.PENDING -> 2.0
+            OpenIapPurchase.PurchaseState.Purchased -> 1.0
+            OpenIapPurchase.PurchaseState.Pending -> 2.0
             else -> 0.0 // UNSPECIFIED/UNKNOWN/other
         }
         return NitroPurchase(
@@ -470,14 +482,14 @@ class HybridRnIap : HybridRnIapSpec() {
     // iOS-specific method - not supported on Android
     override fun getStorefrontIOS(): Promise<String> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
 
     // iOS-specific method - not supported on Android
     override fun getAppTransactionIOS(): Promise<String?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
 
@@ -563,7 +575,7 @@ class HybridRnIap : HybridRnIapSpec() {
             try {
                 // For Android, we need the androidOptions to be provided
                 val androidOptions = params.androidOptions
-                    ?: throw Exception(toErrorJson(OpenIapError.DeveloperError))
+                    ?: throw Exception(toErrorJson(OpenIAPError.DeveloperError))
 
                 // Android receipt validation would typically involve server-side validation
                 // using Google Play Developer API. Here we provide a simplified implementation
@@ -600,7 +612,15 @@ class HybridRnIap : HybridRnIapSpec() {
                 Variant_NitroReceiptValidationResultIOS_NitroReceiptValidationResultAndroid.Second(result)
                 
             } catch (e: Exception) {
-                throw Exception(toErrorJson(OpenIapError.InvalidReceipt("Receipt validation failed: ${e.message}")))
+                val debugMessage = e.message
+                val error = OpenIAPError.InvalidReceipt()
+                throw Exception(
+                    toErrorJson(
+                        error = error,
+                        debugMessage = debugMessage,
+                        messageOverride = debugMessage?.let { "Receipt validation failed: $it" }
+                    )
+                )
             }
         }
     }
@@ -608,31 +628,31 @@ class HybridRnIap : HybridRnIapSpec() {
     // iOS-specific methods - Not applicable on Android, return appropriate defaults
     override fun subscriptionStatusIOS(sku: String): Promise<Array<NitroSubscriptionStatus>?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
     override fun currentEntitlementIOS(sku: String): Promise<NitroPurchase?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
     override fun latestTransactionIOS(sku: String): Promise<NitroPurchase?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
     override fun getPendingTransactionsIOS(): Promise<Array<NitroPurchase>> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
     override fun syncIOS(): Promise<Boolean> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
@@ -640,49 +660,61 @@ class HybridRnIap : HybridRnIapSpec() {
     
     override fun isEligibleForIntroOfferIOS(groupID: String): Promise<Boolean> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
     override fun getReceiptDataIOS(): Promise<String> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
     override fun isTransactionVerifiedIOS(sku: String): Promise<Boolean> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
     
     override fun getTransactionJwsIOS(sku: String): Promise<String?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIapError.NotSupported))
+            throw Exception(toErrorJson(OpenIAPError.NotSupported))
         }
     }
 
     // ---------------------------------------------------------------------
     // OpenIAP error helpers: unify error codes/messages from library
     // ---------------------------------------------------------------------
-    private fun toErrorJson(error: OpenIapError, productId: String? = null): String {
-        val code = OpenIapError.toCode(error)
-        val message = error.message.ifEmpty { OpenIapError.defaultMessage(code) }
+    private fun toErrorJson(
+        error: OpenIAPError,
+        productId: String? = null,
+        debugMessage: String? = null,
+        messageOverride: String? = null
+    ): String {
+        val code = OpenIAPError.toCode(error)
+        val message = messageOverride?.takeIf { it.isNotBlank() }
+            ?: error.message.ifEmpty { OpenIAPError.defaultMessage(code) }
         return BillingUtils.createErrorJson(
             code = code,
             message = message,
             responseCode = -1,
-            debugMessage = error.message,
+            debugMessage = debugMessage ?: error.message,
             productId = productId
         )
     }
 
-    private fun toErrorResult(error: OpenIapError, productId: String? = null): NitroPurchaseResult {
-        val code = OpenIapError.toCode(error)
-        val message = error.message.ifEmpty { OpenIapError.defaultMessage(code) }
+    private fun toErrorResult(
+        error: OpenIAPError,
+        productId: String? = null,
+        debugMessage: String? = null,
+        messageOverride: String? = null
+    ): NitroPurchaseResult {
+        val code = OpenIAPError.toCode(error)
+        val message = messageOverride?.takeIf { it.isNotBlank() }
+            ?: error.message.ifEmpty { OpenIAPError.defaultMessage(code) }
         return NitroPurchaseResult(
             responseCode = -1.0,
-            debugMessage = error.message,
+            debugMessage = debugMessage ?: error.message,
             code = code,
             message = message,
             purchaseToken = null

--- a/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -99,7 +99,12 @@ class HybridRnIap : HybridRnIapSpec() {
                 }
                 if (!ok) {
                     val error = OpenIAPError.InitConnection()
-                    throw Exception(toErrorJson(error))
+                    throw Exception(
+                        toErrorJson(
+                            error = error,
+                            messageOverride = "Failed to initialize connection"
+                        )
+                    )
                 }
                 isInitialized = true
                 deferred.complete(true)
@@ -618,7 +623,7 @@ class HybridRnIap : HybridRnIapSpec() {
                     toErrorJson(
                         error = error,
                         debugMessage = debugMessage,
-                        messageOverride = debugMessage?.let { "Receipt validation failed: $it" }
+                        messageOverride = "Receipt validation failed: ${debugMessage ?: "unknown reason"}"
                     )
                 )
             }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -25,8 +25,7 @@ target 'example' do
   )
 
   # Work around CDN/trunk propagation delay by pulling OpenIAP directly from Git.
-  # This satisfies NitroIap.podspec dependency on 'openiap' (~> 1.1.9).
-  pod 'openiap', :git => 'https://github.com/hyodotdev/openiap-apple.git', :tag => '1.1.9'
+  pod 'openiap', :git => 'https://github.com/hyodotdev/openiap-apple.git', :tag => '1.1.12'
 
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - glog
     - hermes-engine
     - NitroModules
-    - openiap (= 1.1.9)
+    - openiap (= 1.1.12)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -68,7 +68,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - openiap (1.1.9)
+  - openiap (1.1.12)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2501,7 +2501,7 @@ DEPENDENCIES:
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - NitroIap (from `../..`)
   - NitroModules (from `../node_modules/react-native-nitro-modules`)
-  - openiap (from `https://github.com/hyodotdev/openiap-apple.git`, tag `1.1.9`)
+  - openiap (from `https://github.com/hyodotdev/openiap-apple.git`, tag `1.1.12`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native/Libraries/Required`)
@@ -2598,7 +2598,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-nitro-modules"
   openiap:
     :git: https://github.com/hyodotdev/openiap-apple.git
-    :tag: 1.1.9
+    :tag: 1.1.12
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2737,7 +2737,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   openiap:
     :git: https://github.com/hyodotdev/openiap-apple.git
-    :tag: 1.1.9
+    :tag: 1.1.12
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
@@ -2747,9 +2747,9 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroIap: bb4d17eceda5702bfa9b3292bef51f662d392901
+  NitroIap: b63cf218356df7d6675a70f7b9ca9a3b5148b195
   NitroModules: d9c969e83c30ec1e7efc95e0ae58c21db1585c14
-  openiap: dcfa2a4dcf31259ec4b73658e7d1441babccce66
+  openiap: e207e50cc83dc28cd00c3701421a12eacdbd163a
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
@@ -2819,6 +2819,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: fa23995c18b65978347b096d0836f4f5093df545
 
-PODFILE CHECKSUM: cf35f04f73f38d3ba1552cbf18e974f19468fe07
+PODFILE CHECKSUM: d9fcc9189575e14e9124e7cf3a38a3838a96398d
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/plugin/__tests__/withIAP-android.test.ts
+++ b/plugin/__tests__/withIAP-android.test.ts
@@ -51,14 +51,14 @@ describe('withIAP config plugin (Android)', () => {
     const config = makeConfig(initial, {manifest: {}});
     const result: any = plugin(config as any);
     const out = result.modResults.contents as string;
-    expect(out).toContain('io.github.hyochan.openiap:openiap-google:1.1.0');
+    expect(out).toContain('io.github.hyochan.openiap:openiap-google:1.1.10');
     expect((console.log as jest.Mock).mock.calls.join(' ')).toMatch(
-      /Added OpenIAP \(1\.1\.0\) to build\.gradle/,
+      /Added OpenIAP \(1\.1\.10\) to build\.gradle/,
     );
   });
 
   it('is idempotent and respects hasLoggedPluginExecution', () => {
-    const initial = `dependencies {\n    implementation "io.github.hyochan.openiap:openiap-google:1.1.0"\n}`;
+    const initial = `dependencies {\n    implementation "io.github.hyochan.openiap:openiap-google:1.1.10"\n}`;
     const config1 = makeConfig(initial, {manifest: {}});
     const res1: any = plugin(config1 as any);
     expect(

--- a/plugin/src/withIAP.ts
+++ b/plugin/src/withIAP.ts
@@ -46,7 +46,7 @@ export const modifyProjectBuildGradle = (gradle: string): string => {
 };
 
 const OPENIAP_COORD = 'io.github.hyochan.openiap:openiap-google';
-const OPENIAP_VERSION = '1.1.0';
+const OPENIAP_VERSION = '1.1.10';
 
 const modifyAppBuildGradle = (gradle: string): string => {
   let modified = gradle;


### PR DESCRIPTION
Align OpenIAP integration across platforms.

- Upgrade Android fallback/config plugin to use [openiap-google 1.1.10](https://github.com/hyodotdev/openiap-google/releases/tag/1.1.10)
- Bump [iOS pod to openiap 1.1.12](https://github.com/hyodotdev/openiap-apple/releases/tag/1.1.12) and align native error codes with PascalCase constants

Confirm pre-commit suite, Android Kotlin compile, and iOS simulator build succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped OpenIAP dependencies (Android and example to latest 1.1.10, iOS pods to 1.1.12) and aligned plugin tooling.

* **Bug Fixes**
  * Standardized and clarified error codes/messages across iOS and Android for more consistent, informative purchase and receipt error reporting.
  * Improved handling of unsupported features and Android subscription deep-link behavior.

* **Documentation**
  * README updated to reflect the new Android dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->