### PR TITLE
[docs] Update server-side validation library links in lifecycle guide

### DIFF
--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -289,7 +289,7 @@ const goodPurchaseFlow = async (productId) => {
 
 11. **Monitor purchase flow**: Log important events for debugging, but never log sensitive information like receipts or tokens.
 
-12. **Check server-side validation libraries**: Consider using open-source libraries like [node-app-store-receipt-verify](https://github.com/ladeiko/node-app-store-receipt-verify) for iOS or [google-play-billing-validator](https://github.com/macklinu/google-play-billing-validator) for Android.
+12. **Check server-side validation libraries**: Consider using open-source libraries like [node-apple-receipt-verify](https://github.com/ladeiko/node-apple-receipt-verify) for iOS or [google-play-billing-validator](https://github.com/Deishelon/google-play-billing-validator) for Android.
 
 ## Common Pitfalls and Solutions
 


### PR DESCRIPTION
This PR fixes some broken links in the [lifecycle guide](https://hyochan.github.io/react-native-iap/docs/guides/lifecycle#testing-and-development).

The current links return 404 not found.

* https://github.com/ladeiko/node-app-store-receipt-verify &rarr; https://github.com/ladeiko/node-apple-receipt-verify

* https://github.com/macklinu/google-play-billing-validator &rarr; https://github.com/Deishelon/google-play-billing-validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the lifecycle guide to refresh server-side receipt validation recommendations:
    - iOS: switched to the node-apple-receipt-verify library (link updated).
    - Android: updated to a new Google Play billing validator library (link updated).
  * All other guidance remains unchanged.
  * No functional changes to the product; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->