### PR TITLE
refactor!: streamline useIAP purchase handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking
+
+- JS: `useIAP` no longer returns `currentPurchase`, `currentPurchaseError`, or the associated clear helpers; consumers should rely on the `onPurchaseSuccess` / `onPurchaseError` callbacks moving forward.
+
 ## [14.3.5]
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,17 @@ Access these from the Run and Debug panel (⌘⇧D) in VSCode.
 
 ### Commit Message Convention
 
-- **With tag**: Use lowercase after tag (e.g., `feat: add new feature`, `fix: resolve bug`)
-- **Without tag**: Start with uppercase (e.g., `Add new feature`, `Fix critical bug`)
-- Common tags: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
+This repository follows the **Angular Conventional Commits** format:
+
+```
+<type>(<scope>): <subject>
+```
+
+- `type` is one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`.
+- `scope` is optional but encouraged (e.g., `hooks`, `android`).
+- `subject` is imperative, lowercase, ≤ ~50 chars, and has no trailing period.
+- Wrap commit bodies at ~72 columns; include `BREAKING CHANGE:` / `Closes #123` footers when needed.
+- Examples: `feat(auth): add refresh token support`, `chore(ci): bump workflows`.
 
 ### Code Style
 

--- a/example/jest.setup.js
+++ b/example/jest.setup.js
@@ -74,8 +74,6 @@ jest.mock('../src/index', () => ({
     products: [],
     subscriptions: [],
     availablePurchases: [],
-    currentPurchase: undefined,
-    currentPurchaseError: undefined,
     initConnectionAndListen: jest.fn(() => Promise.resolve(true)),
     getProducts: jest.fn(() => Promise.resolve([])),
     getSubscriptions: jest.fn(() => Promise.resolve([])),

--- a/src/__tests__/hooks/useIAP.test.ts
+++ b/src/__tests__/hooks/useIAP.test.ts
@@ -64,8 +64,9 @@ describe('hooks/useIAP (renderer)', () => {
 
   it('connects on mount and updates state on purchase events', async () => {
     let api: any;
+    const onPurchaseSuccess = jest.fn();
     const Harness = () => {
-      api = useIAP();
+      api = useIAP({onPurchaseSuccess});
       return null;
     };
 
@@ -92,7 +93,7 @@ describe('hooks/useIAP (renderer)', () => {
       capturedPurchaseListener?.(purchase);
     });
     await act(async () => {});
-    expect(api.currentPurchase?.productId).toBe('p1');
+    expect(onPurchaseSuccess).toHaveBeenCalledWith(purchase);
 
     // Ensure finishTransaction wrapper works
     await act(async () => {


### PR DESCRIPTION
## Summary
- remove `currentPurchase` / `currentPurchaseError` from `useIAP` in favor of `onPurchaseSuccess` and `onPurchaseError`
- refresh tests, mocks, and docs to align with the leaner hook API

## Testing
- yarn test src/__tests__/hooks/useIAP.test.ts --watchAll=false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional onPurchaseSuccess callback in useIAP to receive purchase details on successful transactions.

- Breaking Changes
  - Removed currentPurchase and currentPurchaseError from useIAP, along with their clear functions. Migrate to the onPurchaseSuccess callback for purchase handling.
  - Test/mocking surface adjusted accordingly.

- Documentation
  - Updated commit message guidelines to follow the Angular Conventional Commits format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->