### PR TITLE
refactor: align hybrid spec impl on ios and android

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -36,5 +36,10 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Ensure generated types are up to date
+        run: |
+          yarn generate:types
+          git diff --exit-code -- src/types.ts
+
       - name: Build package
         run: node .yarn/releases/yarn-3.6.1.cjs prepare

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ example-expo/          # Independent Expo example app (NOT in workspace)
 ### Auto-generated Files
 
 - `src/types.ts` is generated; never edit manually. Update the underlying schema/spec and rerun the generators instead.
+- When declaring API params/results in JS/TS modules, import the canonical types from `src/types.ts` rather than creating ad-hoc interfaces.
 
 ## Development Commands
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -92,6 +92,34 @@ export const fetchProducts = async (params) => {
 };
 ```
 
+### Generated API Helpers
+
+- When an API surface lives in the shared schema (`src/types.ts`), prefer the generated helpers (`QueryField`, `MutationField`, etc.) instead of hand-written parameter/return types. This keeps JavaScript, TypeScript, and the Nitro bridge in sync.
+
+```typescript
+// ✅ Good – signature driven by generated helpers
+export const fetchProducts: QueryField<'fetchProducts'> = async (request) => {
+  // request typed from src/types.ts
+};
+
+export const finishTransaction: MutationField<'finishTransaction'> = async (
+  args,
+) => {
+  const {purchase} = args;
+  // ...
+};
+
+// ❌ Bad – manual types drift from the schema over time
+export const fetchProducts = async (request: {
+  skus: string[];
+  type?: 'in-app' | 'subs';
+}): Promise<{products: Product[]; subscriptions: ProductSubscription[]}> => {
+  // ...
+};
+```
+
+- `src/index.ts` must only expose APIs that are declared in the canonical schema (`src/types.ts`). If the schema changes, update it first, regenerate as needed, and then adjust `index.ts` to match.
+
 ## Platform-Specific Naming
 
 ### Naming Rules
@@ -174,11 +202,6 @@ export const requestPurchase = async (productId: string): Promise<Purchase> => {
 
 ```typescript
 // BAD: iOS-only function without suffix
-export const getStorefront = (): Promise<string> => {
-  return ExpoIapModule.getStorefront(); // Only works on iOS!
-};
-
-// GOOD: Should be
 export const getStorefrontIOS = (): Promise<string> => {
   // Platform check and implementation
 };
@@ -460,10 +483,6 @@ export const getStorefrontIOS = async (): Promise<string> => {
 /**
  * @deprecated Use getStorefrontIOS instead
  */
-export const getStorefront = async (): Promise<string> => {
-  console.warn('getStorefront is deprecated. Use getStorefrontIOS instead.');
-  return getStorefrontIOS();
-};
 ```
 
 ## New v2.7.0 API Guidelines

--- a/example-expo/app/purchase-flow.tsx
+++ b/example-expo/app/purchase-flow.tsx
@@ -188,13 +188,15 @@ const PurchaseFlow: React.FC = () => {
   const loadProducts = async () => {
     try {
       setLoading(true);
-      const fetchedProducts = await fetchProducts({
+      const fetchedProductsResult = await fetchProducts({
         skus: PRODUCT_IDS,
         type: PRODUCT_QUERY_TYPE_IN_APP,
       });
 
-      // Products fetched successfully
-      setProducts(fetchedProducts);
+      const inAppProducts = (fetchedProductsResult ?? []).filter(
+        (item) => item.type === 'in-app',
+      );
+      setProducts(inAppProducts as Product[]);
     } catch {
       // Failed to load products
       Alert.alert('Error', 'Failed to load products');

--- a/example/__tests__/RnIap.test.tsx
+++ b/example/__tests__/RnIap.test.tsx
@@ -28,9 +28,8 @@ jest.mock('react-native-nitro-modules', () => ({
       getStorefrontIOS: jest.fn().mockResolvedValue('USA'),
       getAppTransactionIOS: jest.fn().mockResolvedValue(null),
       requestPromotedProductIOS: jest.fn().mockResolvedValue(null),
-      buyPromotedProductIOS: jest.fn().mockResolvedValue(undefined),
       presentCodeRedemptionSheetIOS: jest.fn().mockResolvedValue(true),
-      clearTransactionIOS: jest.fn().mockResolvedValue(undefined),
+      clearTransactionIOS: jest.fn().mockResolvedValue(true),
       beginRefundRequestIOS: jest.fn().mockResolvedValue(null),
       acknowledgePurchaseAndroid: jest.fn().mockResolvedValue(true),
       consumePurchaseAndroid: jest.fn().mockResolvedValue(true),
@@ -101,7 +100,10 @@ describe('RnIap Complete Test Suite', () => {
     it('should request purchase', async () => {
       const request = {ios: {sku: 'product1'}};
       await expect(
-        RNIap.requestPurchase({request, type: 'in-app'}),
+        RNIap.requestPurchase({
+          request,
+          type: 'in-app',
+        }),
       ).resolves.not.toThrow();
     });
 
@@ -142,11 +144,6 @@ describe('RnIap Complete Test Suite', () => {
       expect(typeof RNIap.requestPromotedProductIOS).toBe('function');
     });
 
-    it('should export buyPromotedProductIOS', () => {
-      expect(RNIap.buyPromotedProductIOS).toBeDefined();
-      expect(typeof RNIap.buyPromotedProductIOS).toBe('function');
-    });
-
     it('should export presentCodeRedemptionSheetIOS', () => {
       expect(RNIap.presentCodeRedemptionSheetIOS).toBeDefined();
       expect(typeof RNIap.presentCodeRedemptionSheetIOS).toBe('function');
@@ -163,22 +160,16 @@ describe('RnIap Complete Test Suite', () => {
     });
 
     it('should present code redemption sheet on iOS', async () => {
-      await expect(
-        RNIap.presentCodeRedemptionSheetIOS(),
-      ).resolves.not.toThrow();
+      await expect(RNIap.presentCodeRedemptionSheetIOS()).resolves.toBe(true);
     });
 
     it('should clear transactions on iOS', async () => {
-      await expect(RNIap.clearTransactionIOS()).resolves.not.toThrow();
+      await expect(RNIap.clearTransactionIOS()).resolves.toBe(true);
     });
 
     it('should request promoted product on iOS', async () => {
       const result = await RNIap.requestPromotedProductIOS();
       expect(result).toBeNull();
-    });
-
-    it('should buy promoted product on iOS', async () => {
-      await expect(RNIap.buyPromotedProductIOS()).resolves.not.toThrow();
     });
 
     it('should begin refund request on iOS', async () => {

--- a/example/__tests__/screens/PurchaseFlow.test.tsx
+++ b/example/__tests__/screens/PurchaseFlow.test.tsx
@@ -116,7 +116,8 @@ describe('PurchaseFlow Screen', () => {
 
     await waitFor(() => {
       expect(RNIap.fetchProducts).toHaveBeenCalledWith({
-        products: ['dev.hyo.martie.10bulbs', 'dev.hyo.martie.30bulbs'],
+        skus: ['dev.hyo.martie.10bulbs', 'dev.hyo.martie.30bulbs'],
+        type: 'in-app',
       });
     });
   });
@@ -216,8 +217,15 @@ describe('PurchaseFlow Screen', () => {
 
     await waitFor(() => {
       expect(RNIap.requestPurchase).toHaveBeenCalledWith({
-        sku: 'dev.hyo.martie.10bulbs',
-        andDangerouslyFinishTransactionAutomatically: false,
+        request: expect.objectContaining({
+          ios: expect.objectContaining({
+            sku: 'dev.hyo.martie.10bulbs',
+          }),
+          android: expect.objectContaining({
+            skus: ['dev.hyo.martie.10bulbs'],
+          }),
+        }),
+        type: 'in-app',
       });
     });
   });

--- a/example/__tests__/screens/SubscriptionFlow.test.tsx
+++ b/example/__tests__/screens/SubscriptionFlow.test.tsx
@@ -27,7 +27,6 @@ const mockUseIAP = {
   getAvailablePurchases: jest.fn().mockResolvedValue([]),
   getActiveSubscriptions: jest.fn().mockResolvedValue([]),
   requestPurchase: jest.fn(),
-  requestSubscription: jest.fn(),
   finishTransaction: jest.fn(),
   fetchProducts: jest.fn(),
 };

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - NitroIap (14.3.4):
+  - NitroIap (14.3.7):
     - boost
     - DoubleConversion
     - fast_float
@@ -2747,7 +2747,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroIap: b63cf218356df7d6675a70f7b9ca9a3b5148b195
+  NitroIap: 01ecf4d85ec32154d18b6f97660e9b968f55fb00
   NitroModules: d9c969e83c30ec1e7efc95e0ae58c21db1585c14
   openiap: e207e50cc83dc28cd00c3701421a12eacdbd163a
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
@@ -2821,4 +2821,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d9fcc9189575e14e9124e7cf3a38a3838a96398d
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/jest.setup.js
+++ b/example/jest.setup.js
@@ -16,7 +16,6 @@ jest.mock('react-native-nitro-modules', () => ({
       getProducts: jest.fn(() => Promise.resolve([])),
       getSubscriptions: jest.fn(() => Promise.resolve([])),
       requestPurchase: jest.fn(() => Promise.resolve()),
-      requestSubscription: jest.fn(() => Promise.resolve()),
       finishTransaction: jest.fn(() => Promise.resolve()),
       getAvailablePurchases: jest.fn(() => Promise.resolve([])),
       getPurchaseHistory: jest.fn(() => Promise.resolve([])),
@@ -25,7 +24,6 @@ jest.mock('react-native-nitro-modules', () => ({
       clearTransactionIOS: jest.fn(() => Promise.resolve()),
       clearProductsIOS: jest.fn(() => Promise.resolve()),
       promotedProductIOS: jest.fn(() => Promise.resolve()),
-      buyPromotedProductIOS: jest.fn(() => Promise.resolve()),
       requestPromotedProductIOS: jest.fn(() => Promise.resolve()),
       validateReceiptIos: jest.fn(() => Promise.resolve()),
       deepLinkingGetPendingPurchases: jest.fn(() => Promise.resolve()),
@@ -43,26 +41,24 @@ jest.mock('../src/index', () => ({
   getSubscriptions: jest.fn(() => Promise.resolve([])),
   fetchProducts: jest.fn(() => Promise.resolve([])),
   requestPurchase: jest.fn(() => Promise.resolve()),
-  requestSubscription: jest.fn(() => Promise.resolve()),
   finishTransaction: jest.fn(() => Promise.resolve()),
   getAvailablePurchases: jest.fn(() => Promise.resolve([])),
   getPurchaseHistory: jest.fn(() => Promise.resolve([])),
 
   // Android specific
-  acknowledgePurchaseAndroid: jest.fn(() => Promise.resolve()),
-  consumePurchaseAndroid: jest.fn(() => Promise.resolve()),
+  acknowledgePurchaseAndroid: jest.fn(() => Promise.resolve(true)),
+  consumePurchaseAndroid: jest.fn(() => Promise.resolve(true)),
   deepLinkingGetPendingPurchases: jest.fn(() => Promise.resolve()),
   validateReceiptAndroid: jest.fn(() => Promise.resolve()),
 
   // iOS specific
-  clearTransactionIOS: jest.fn(() => Promise.resolve()),
+  clearTransactionIOS: jest.fn(() => Promise.resolve(true)),
   clearProductsIOS: jest.fn(() => Promise.resolve()),
   promotedProductIOS: jest.fn(() => Promise.resolve()),
-  buyPromotedProductIOS: jest.fn(() => Promise.resolve()),
   requestPromotedProductIOS: jest.fn(() => Promise.resolve(null)),
   beginRefundRequestIOS: jest.fn(() => Promise.resolve(null)),
   validateReceiptIos: jest.fn(() => Promise.resolve()),
-  presentCodeRedemptionSheetIOS: jest.fn(() => Promise.resolve()),
+  presentCodeRedemptionSheetIOS: jest.fn(() => Promise.resolve(true)),
 
   // Event listeners
   purchaseUpdatedListener: jest.fn((callback) => ({remove: jest.fn()})),
@@ -79,7 +75,6 @@ jest.mock('../src/index', () => ({
     getSubscriptions: jest.fn(() => Promise.resolve([])),
     getAvailablePurchases: jest.fn(() => Promise.resolve([])),
     requestPurchase: jest.fn(() => Promise.resolve()),
-    requestSubscription: jest.fn(() => Promise.resolve()),
     finishTransaction: jest.fn(() => Promise.resolve()),
   })),
 

--- a/example/screens/PurchaseFlow.tsx
+++ b/example/screens/PurchaseFlow.tsx
@@ -184,13 +184,15 @@ const PurchaseFlow: React.FC = () => {
   const loadProducts = async () => {
     try {
       setLoading(true);
-      const fetchedProducts = await fetchProducts({
+      const fetchedProductsResult = await fetchProducts({
         skus: PRODUCT_IDS,
         type: PRODUCT_QUERY_TYPE_IN_APP,
       });
 
-      // Products fetched successfully
-      setProducts(fetchedProducts);
+      const purchasedProducts = (fetchedProductsResult ?? []).filter(
+        (item) => item.type === 'in-app',
+      );
+      setProducts(purchasedProducts as Product[]);
     } catch {
       // Failed to load products
       Alert.alert('Error', 'Failed to load products');

--- a/ios/HybridRnIap.swift
+++ b/ios/HybridRnIap.swift
@@ -89,7 +89,7 @@ class HybridRnIap: HybridRnIapSpec {
                                     minimal.id = id
                                     minimal.title = id
                                     minimal.type = "inapp"
-                                    minimal.platform = "ios"
+                                    minimal.platform = .ios
                                     for listener in self.promotedProductListeners { listener(minimal) }
                                     }
                                 }
@@ -147,7 +147,7 @@ class HybridRnIap: HybridRnIapSpec {
                                 minimal.id = id
                                 minimal.title = id
                                 minimal.type = "inapp"
-                                minimal.platform = "ios"
+                                minimal.platform = .ios
                                 for listener in self.promotedProductListeners { listener(minimal) }
                             }
                         }
@@ -200,7 +200,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func requestPurchase(request: NitroPurchaseRequest) throws -> Promise<RequestPurchaseResult> {
         return Promise.async {
-            let defaultResult = RequestPurchaseResult(purchase: nil, purchases: nil)
+            let defaultResult: RequestPurchaseResult = .third([])
             guard let iosRequest = request.ios else {
                 let error = self.createPurchaseErrorResult(
                     code: OpenIapError.UserError,
@@ -358,7 +358,7 @@ class HybridRnIap: HybridRnIapSpec {
                     n.title = p.localizedTitle
                     n.description = p.localizedDescription
                     n.type = "inapp"
-                    n.platform = "ios"
+                    n.platform = .ios
                     n.price = p.price
                     n.currency = p.priceLocale.currencyCode
                     return n
@@ -569,7 +569,7 @@ class HybridRnIap: HybridRnIapSpec {
                     n.title = title
                     n.description = desc
                     n.type = "inapp"
-                    n.platform = "ios"
+                    n.platform = .ios
                     n.price = price
                     n.currency = currency
                     listener(n)
@@ -689,7 +689,9 @@ class HybridRnIap: HybridRnIapSpec {
         n.displayPrice = p.displayPrice
         n.currency = p.currency
         n.price = p.price
-        n.platform = p.platform
+        if let platform = IapPlatform(fromString: p.platform) {
+            n.platform = platform
+        }
         // iOS specifics
         n.typeIOS = p.typeIOS.rawValue
         n.isFamilyShareableIOS = p.isFamilyShareableIOS
@@ -710,9 +712,13 @@ class HybridRnIap: HybridRnIapSpec {
         n.productId = p.productId
         n.transactionDate = p.transactionDate
         n.purchaseToken = p.purchaseToken
-        n.platform = p.platform
+        if let platform = IapPlatform(fromString: p.platform) {
+            n.platform = platform
+        }
         n.quantity = Double(p.quantity)
-        n.purchaseState = p.purchaseState.rawValue
+        if let state = PurchaseState(fromString: p.purchaseState.rawValue) {
+            n.purchaseState = state
+        }
         n.isAutoRenewing = p.isAutoRenewing
         // iOS specifics
         if let q = p.quantityIOS { n.quantityIOS = Double(q) }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prepare:husky": "husky install",
     "precommit": "lint-staged",
     "ci:check": "./scripts/ci-check.sh",
-    "generate:types": "node scripts/update-types.mjs --tag 1.0.3",
+    "generate:types": "node scripts/update-types.mjs --tag 1.0.6",
     "generate:icon": "cd docs/static/img && npx sharp-cli resize 32 32 --input icon.png --output favicon-32x32.png && npx sharp-cli resize 16 16 --input icon.png --output favicon-16x16.png && npx sharp-cli resize 192 192 --input icon.png --output android-chrome-192x192.png && npx sharp-cli resize 512 512 --input icon.png --output android-chrome-512x512.png && npx sharp-cli resize 180 180 --input icon.png --output apple-touch-icon.png && npx sharp-cli resize 1200 630 --input icon.png --output og-image.png && npx sharp-cli resize 150 150 --input icon.png --output favicon.png && npx sharp-cli --input favicon-32x32.png --output favicon.ico",
     "commitlint": "commitlint"
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prepare:husky": "husky install",
     "precommit": "lint-staged",
     "ci:check": "./scripts/ci-check.sh",
-    "generate:types": "node scripts/update-types.mjs --tag 1.0.2",
+    "generate:types": "node scripts/update-types.mjs --tag 1.0.3",
     "generate:icon": "cd docs/static/img && npx sharp-cli resize 32 32 --input icon.png --output favicon-32x32.png && npx sharp-cli resize 16 16 --input icon.png --output favicon-16x16.png && npx sharp-cli resize 192 192 --input icon.png --output android-chrome-192x192.png && npx sharp-cli resize 512 512 --input icon.png --output android-chrome-512x512.png && npx sharp-cli resize 180 180 --input icon.png --output apple-touch-icon.png && npx sharp-cli resize 1200 630 --input icon.png --output og-image.png && npx sharp-cli resize 150 150 --input icon.png --output favicon.png && npx sharp-cli --input favicon-32x32.png --output favicon.ico",
     "commitlint": "commitlint"
   },

--- a/src/__tests__/hooks/useIAP.test.ts
+++ b/src/__tests__/hooks/useIAP.test.ts
@@ -48,7 +48,7 @@ describe('hooks/useIAP (renderer)', () => {
   beforeEach(() => {
     jest.spyOn(IAP, 'initConnection').mockResolvedValue(true as any);
     jest.spyOn(IAP, 'getAvailablePurchases').mockResolvedValue([] as any);
-    jest.spyOn(IAP, 'finishTransaction').mockResolvedValue(true as any);
+    jest.spyOn(IAP, 'finishTransaction').mockResolvedValue(undefined as any);
     jest.spyOn(IAP, 'purchaseUpdatedListener').mockImplementation((cb: any) => {
       capturedPurchaseListener = cb;
       return {remove: jest.fn()};

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -213,50 +213,50 @@ describe('Public API (src/index.ts)', () => {
         skus: ['a', 'b'],
         type: 'in-app',
       });
-      expect(products.map((p: any) => p.id)).toEqual(['a']);
+      expect((products ?? []).map((p: any) => p.id)).toEqual(['a']);
       expect(warn).toHaveBeenCalled();
       warn.mockRestore();
     });
 
     it('fetches both inapp and subs when type = all', async () => {
       (Platform as any).OS = 'android';
-      mockIap.fetchProducts
-        .mockResolvedValueOnce([
-          {
-            id: 'x',
-            title: 'X',
-            description: 'dx',
-            type: 'inapp',
-            platform: 'android',
-            displayPrice: '$1.00',
-            currency: 'USD',
-          },
-        ])
-        .mockResolvedValueOnce([
-          {
-            id: 'y',
-            title: 'Y',
-            description: 'dy',
-            type: 'subs',
-            platform: 'android',
-            displayPrice: '$2.00',
-            currency: 'USD',
-          },
-        ]);
+      mockIap.fetchProducts.mockResolvedValueOnce([
+        {
+          id: 'x',
+          title: 'X',
+          description: 'dx',
+          type: 'inapp',
+          platform: 'android',
+          displayPrice: '$1.00',
+          currency: 'USD',
+        },
+        {
+          id: 'y',
+          title: 'Y',
+          description: 'dy',
+          type: 'subs',
+          platform: 'android',
+          displayPrice: '$2.00',
+          currency: 'USD',
+        },
+      ]);
       const result = await IAP.fetchProducts({
         skus: ['x', 'y'],
         type: 'all',
       });
-      expect(result.map((p: any) => p.id).sort()).toEqual(['x', 'y']);
+      const items = result ?? [];
+      const productIds = items
+        .filter((item: any) => item.type === 'in-app')
+        .map((item: any) => item.id);
+      const subscriptionIds = items
+        .filter((item: any) => item.type === 'subs')
+        .map((item: any) => item.id);
+      expect(productIds).toEqual(['x']);
+      expect(subscriptionIds).toEqual(['y']);
       expect(mockIap.fetchProducts).toHaveBeenNthCalledWith(
         1,
         ['x', 'y'],
-        'inapp',
-      );
-      expect(mockIap.fetchProducts).toHaveBeenNthCalledWith(
-        2,
-        ['x', 'y'],
-        'subs',
+        'all',
       );
     });
   });
@@ -396,7 +396,7 @@ describe('Public API (src/index.ts)', () => {
   });
 
   describe('finishTransaction', () => {
-    it('iOS requires purchase.id and returns boolean', async () => {
+    it('iOS requires purchase.id and returns success state', async () => {
       (Platform as any).OS = 'ios';
       await expect(
         IAP.finishTransaction({purchase: {id: ''} as any}),
@@ -405,7 +405,7 @@ describe('Public API (src/index.ts)', () => {
       mockIap.finishTransaction.mockResolvedValueOnce(true);
       await expect(
         IAP.finishTransaction({purchase: {id: 'tid'} as any}),
-      ).resolves.toBe(true);
+      ).resolves.toBeUndefined();
     });
 
     it('Android requires token; maps consume flag', async () => {
@@ -436,7 +436,7 @@ describe('Public API (src/index.ts)', () => {
       );
       await expect(
         IAP.finishTransaction({purchase: {id: 'tid'} as any}),
-      ).resolves.toBe(true);
+      ).resolves.toBeUndefined();
     });
   });
 
@@ -525,18 +525,28 @@ describe('Public API (src/index.ts)', () => {
       expect(p2?.id).toBe('sku2');
     });
 
-    it('buyPromotedProductIOS and alias requestPurchaseOnPromotedProductIOS call native', async () => {
+    it('requestPurchaseOnPromotedProductIOS triggers native purchase', async () => {
       (Platform as any).OS = 'ios';
       mockIap.buyPromotedProductIOS = jest.fn(async () => undefined);
-      await IAP.buyPromotedProductIOS();
-      await IAP.requestPurchaseOnPromotedProductIOS();
-      expect(mockIap.buyPromotedProductIOS).toHaveBeenCalledTimes(2);
+      const pending = {
+        id: 'tid',
+        productId: 'sku2',
+        transactionDate: Date.now(),
+        platform: 'ios',
+        quantity: 1,
+        purchaseState: 'purchased',
+        isAutoRenewing: false,
+      } as any;
+      mockIap.getPendingTransactionsIOS = jest.fn(async () => [pending]);
+      const result = await IAP.requestPurchaseOnPromotedProductIOS();
+      expect(result.productId).toBe('sku2');
+      expect(mockIap.buyPromotedProductIOS).toHaveBeenCalledTimes(1);
     });
 
     it('clearTransactionIOS resolves without throwing', async () => {
       (Platform as any).OS = 'ios';
       mockIap.clearTransactionIOS = jest.fn(async () => undefined);
-      await expect(IAP.clearTransactionIOS()).resolves.toBeUndefined();
+      await expect(IAP.clearTransactionIOS()).resolves.toBe(true);
     });
 
     it('beginRefundRequestIOS returns status string', async () => {
@@ -612,10 +622,7 @@ describe('Public API (src/index.ts)', () => {
     it('restorePurchases on iOS calls syncIOS first', async () => {
       (Platform as any).OS = 'ios';
       mockIap.syncIOS = jest.fn(async () => true);
-      await IAP.restorePurchases({
-        alsoPublishToEventListenerIOS: false,
-        onlyIncludeActiveItemsIOS: true,
-      });
+      await IAP.restorePurchases();
       expect(mockIap.syncIOS).toHaveBeenCalled();
     });
   });
@@ -630,7 +637,7 @@ describe('Public API (src/index.ts)', () => {
         purchaseToken: 'tok',
       });
       const res = await IAP.acknowledgePurchaseAndroid('tok');
-      expect(res.responseCode).toBe(0);
+      expect(res).toBe(true);
       expect(mockIap.finishTransaction).toHaveBeenCalledWith({
         android: {purchaseToken: 'tok', isConsumable: false},
       });
@@ -645,7 +652,7 @@ describe('Public API (src/index.ts)', () => {
         purchaseToken: 'tok',
       });
       const res = await IAP.consumePurchaseAndroid('tok');
-      expect(res.responseCode).toBe(0);
+      expect(res).toBe(true);
       expect(mockIap.finishTransaction).toHaveBeenCalledWith({
         android: {purchaseToken: 'tok', isConsumable: true},
       });
@@ -661,7 +668,9 @@ describe('Public API (src/index.ts)', () => {
         jwsRepresentation: 'jws',
         latestTransaction: null,
       });
-      const res = await IAP.validateReceipt('sku');
+      const res = await IAP.validateReceipt({
+        sku: 'sku',
+      });
       expect(res).toEqual(
         expect.objectContaining({
           isValid: true,
@@ -693,10 +702,13 @@ describe('Public API (src/index.ts)', () => {
         termSku: 'termSku',
         testTransaction: false,
       });
-      const res = await IAP.validateReceipt('sku', {
-        packageName: 'com.app',
-        productToken: 'tok',
-        accessToken: 'acc',
+      const res = await IAP.validateReceipt({
+        sku: 'sku',
+        androidOptions: {
+          packageName: 'com.app',
+          productToken: 'tok',
+          accessToken: 'acc',
+        },
       });
       expect(res).toEqual(
         expect.objectContaining({productId: 'sku', productType: 'inapp'}),
@@ -747,7 +759,7 @@ describe('Public API (src/index.ts)', () => {
     it('restorePurchases on Android does not call syncIOS', async () => {
       (Platform as any).OS = 'android';
       mockIap.syncIOS = jest.fn(async () => true);
-      await expect(IAP.restorePurchases()).resolves.toEqual(expect.any(Array));
+      await expect(IAP.restorePurchases()).resolves.toBeUndefined();
       expect(mockIap.syncIOS).not.toHaveBeenCalled();
     });
   });
@@ -762,30 +774,16 @@ describe('Public API (src/index.ts)', () => {
     });
   });
 
-  describe('Cross‑platform storefront and deeplink helpers', () => {
-    it('getStorefront returns Android storefront or empty string on failure', async () => {
-      (Platform as any).OS = 'android';
-      mockIap.getStorefrontAndroid = jest.fn(async () => 'US');
-      await expect(IAP.getStorefront()).resolves.toBe('US');
-
-      // Failure path returns empty string
-      mockIap.getStorefrontAndroid = jest.fn(async () => {
-        throw new Error('nope');
-      });
-      await expect(IAP.getStorefront()).resolves.toBe('');
-
-      // Optional method missing also returns empty string
-      delete mockIap.getStorefrontAndroid;
-      await expect(IAP.getStorefront()).resolves.toBe('');
-    });
-
+  describe('Cross‑platform helpers', () => {
     it('deepLinkToSubscriptions calls Android native deeplink when on Android', async () => {
       (Platform as any).OS = 'android';
       mockIap.deepLinkToSubscriptionsAndroid = jest.fn(async () => undefined);
-      await IAP.deepLinkToSubscriptions({
-        skuAndroid: 'sub1',
-        packageNameAndroid: 'dev.hyo.martie',
-      });
+      await expect(
+        IAP.deepLinkToSubscriptions({
+          skuAndroid: 'sub1',
+          packageNameAndroid: 'dev.hyo.martie',
+        }),
+      ).resolves.toBeUndefined();
       expect(mockIap.deepLinkToSubscriptionsAndroid).toHaveBeenCalledWith({
         skuAndroid: 'sub1',
         packageNameAndroid: 'dev.hyo.martie',
@@ -795,7 +793,7 @@ describe('Public API (src/index.ts)', () => {
     it('deepLinkToSubscriptions uses iOS manage subscriptions on iOS', async () => {
       (Platform as any).OS = 'ios';
       mockIap.showManageSubscriptionsIOS = jest.fn(async () => []);
-      await IAP.deepLinkToSubscriptions();
+      await expect(IAP.deepLinkToSubscriptions()).resolves.toBeUndefined();
       expect(mockIap.showManageSubscriptionsIOS).toHaveBeenCalled();
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import {NitroModules} from 'react-native-nitro-modules';
 
 // Internal modules
 import type {
-  NitroPurchaseResult,
   NitroReceiptValidationParams,
   NitroReceiptValidationResultIOS,
   NitroReceiptValidationResultAndroid,
@@ -14,19 +13,17 @@ import type {
   RnIap,
 } from './specs/RnIap.nitro';
 import type {
-  ProductQueryType,
-  RequestPurchaseProps,
-  RequestPurchaseResult,
-} from './types';
-import type {
   AndroidSubscriptionOfferInput,
   DiscountOfferInputIOS,
+  FetchProductsResult,
+  MutationField,
   Product,
-  ProductRequest,
+  ProductIOS,
+  ProductQueryType,
   Purchase,
-  PurchaseAndroid,
-  PurchaseOptions,
   PurchaseError,
+  PurchaseIOS,
+  QueryField,
   ReceiptValidationResultAndroid,
   ReceiptValidationResultIOS,
   RequestPurchaseAndroidProps,
@@ -35,17 +32,18 @@ import type {
   RequestSubscriptionAndroidProps,
   RequestSubscriptionIosProps,
   RequestSubscriptionPropsByPlatforms,
-  SubscriptionStatusIOS,
 } from './types';
 import {
   convertNitroProductToProduct,
   convertNitroPurchaseToPurchase,
+  convertProductToProductSubscription,
   validateNitroProduct,
   validateNitroPurchase,
   convertNitroSubscriptionStatusToSubscriptionStatusIOS,
 } from './utils/type-bridge';
 import {parseErrorStringToJsonObj} from './utils/error';
 import {normalizeErrorCodeFromNative} from './utils/errorMapping';
+import {getSuccessFromPurchaseVariant} from './utils/purchase';
 
 // Export all types
 export type {
@@ -89,105 +87,16 @@ const toErrorMessage = (error: unknown): string => {
   return String(error ?? '');
 };
 
-type NitroDiscountOfferRecord = NonNullable<
-  NonNullable<NitroPurchaseRequest['ios']>['withOffer']
->;
-
-const toDiscountOfferRecordIOS = (
-  offer: DiscountOfferInputIOS | null | undefined,
-): NitroDiscountOfferRecord | undefined => {
-  if (!offer) {
-    return undefined;
-  }
-  return {
-    identifier: offer.identifier,
-    keyIdentifier: offer.keyIdentifier,
-    nonce: offer.nonce,
-    signature: offer.signature,
-    timestamp: String(offer.timestamp),
-  };
-};
-
-function toNitroProductType(
-  type?: ProductTypeInput | ProductQueryType | null,
-): 'inapp' | 'subs' {
-  if (type === 'subs') {
-    return 'subs';
-  }
-  if (type === 'inapp') {
-    console.warn(LEGACY_INAPP_WARNING);
-    return 'inapp';
-  }
-  if (type === 'all') {
-    return 'inapp';
-  }
-  return 'inapp';
-}
-
-function isSubscriptionQuery(type?: ProductQueryType | null): boolean {
-  return type === 'subs';
-}
-
-function normalizeProductQueryType(
-  type?: ProductQueryType | string | null,
-): ProductQueryType {
-  if (type === 'all' || type === 'subs' || type === 'in-app') {
-    return type;
-  }
-
-  if (typeof type === 'string') {
-    const normalized = type.trim().toLowerCase().replace(/_/g, '-');
-
-    if (normalized === 'all') {
-      return 'all';
-    }
-    if (normalized === 'subs') {
-      return 'subs';
-    }
-    if (normalized === 'inapp') {
-      console.warn(LEGACY_INAPP_WARNING);
-      return 'in-app';
-    }
-    if (normalized === 'in-app') {
-      return 'in-app';
-    }
-  }
-  return 'in-app';
-}
-
 export interface EventSubscription {
   remove(): void;
 }
-
-export type FinishTransactionParams = {
-  purchase: Purchase;
-  isConsumable?: boolean;
-};
 
 // ActiveSubscription and PurchaseError types are already exported via 'export * from ./types'
 
 // Export hooks
 export {useIAP} from './hooks/useIAP';
 
-// iOS promoted product aliases for API parity
-export const getPromotedProductIOS = async (): Promise<Product | null> =>
-  requestPromotedProductIOS();
-export const requestPurchaseOnPromotedProductIOS = async (): Promise<void> =>
-  buyPromotedProductIOS();
-
 // Restore completed transactions (cross-platform)
-export const restorePurchases = async (
-  options: PurchaseOptions = {
-    alsoPublishToEventListenerIOS: false,
-    onlyIncludeActiveItemsIOS: true,
-  },
-): Promise<Purchase[]> => {
-  if (Platform.OS === 'ios') {
-    await syncIOS();
-  }
-  return getAvailablePurchases(options);
-};
-
 // Development utilities removed - use type bridge functions directly if needed
 
 // Create the RnIap HybridObject instance lazily to avoid early JSI crashes
@@ -218,31 +127,167 @@ const IAP = {
   },
 };
 
-/**
- * Initialize connection to the store
- */
-export const initConnection = async (): Promise<boolean> => {
+// ============================================================================
+// EVENT LISTENERS
+// ============================================================================
+
+const purchaseUpdatedListenerMap = new WeakMap<
+  (purchase: Purchase) => void,
+  NitroPurchaseListener
+>();
+const purchaseErrorListenerMap = new WeakMap<
+  (error: PurchaseError) => void,
+  NitroPurchaseErrorListener
+>();
+const promotedProductListenerMap = new WeakMap<
+  (product: Product) => void,
+  NitroPromotedProductListener
+>();
+
+export const purchaseUpdatedListener = (
+  listener: (purchase: Purchase) => void,
+): EventSubscription => {
+  const wrappedListener: NitroPurchaseListener = (nitroPurchase) => {
+    if (validateNitroPurchase(nitroPurchase)) {
+      const convertedPurchase = convertNitroPurchaseToPurchase(nitroPurchase);
+      listener(convertedPurchase);
+    } else {
+      console.error(
+        'Invalid purchase data received from native:',
+        nitroPurchase,
+      );
+    }
+  };
+
+  purchaseUpdatedListenerMap.set(listener, wrappedListener);
+  let attached = false;
   try {
-    return await IAP.instance.initConnection();
-  } catch (error) {
-    console.error('Failed to initialize IAP connection:', error);
-    throw error;
+    IAP.instance.addPurchaseUpdatedListener(wrappedListener);
+    attached = true;
+  } catch (e) {
+    const msg = toErrorMessage(e);
+    if (msg.includes('Nitro runtime not installed')) {
+      console.warn(
+        '[purchaseUpdatedListener] Nitro not ready yet; listener inert until initConnection()',
+      );
+    } else {
+      throw e;
+    }
   }
+
+  return {
+    remove: () => {
+      const wrapped = purchaseUpdatedListenerMap.get(listener);
+      if (wrapped) {
+        if (attached) {
+          try {
+            IAP.instance.removePurchaseUpdatedListener(wrapped);
+          } catch {}
+        }
+        purchaseUpdatedListenerMap.delete(listener);
+      }
+    },
+  };
 };
 
-/**
- * End connection to the store
- */
-export const endConnection = async (): Promise<boolean> => {
+export const purchaseErrorListener = (
+  listener: (error: PurchaseError) => void,
+): EventSubscription => {
+  const wrapped: NitroPurchaseErrorListener = (error) => {
+    listener({
+      code: normalizeErrorCodeFromNative(error.code),
+      message: error.message,
+      productId: undefined,
+    });
+  };
+
+  purchaseErrorListenerMap.set(listener, wrapped);
+  let attached = false;
   try {
-    // If never initialized, treat as ended
-    if (!iapRef) return true;
-    return await IAP.instance.endConnection();
-  } catch (error) {
-    console.error('Failed to end IAP connection:', error);
-    throw error;
+    IAP.instance.addPurchaseErrorListener(wrapped);
+    attached = true;
+  } catch (e) {
+    const msg = toErrorMessage(e);
+    if (msg.includes('Nitro runtime not installed')) {
+      console.warn(
+        '[purchaseErrorListener] Nitro not ready yet; listener inert until initConnection()',
+      );
+    } else {
+      throw e;
+    }
   }
+
+  return {
+    remove: () => {
+      const stored = purchaseErrorListenerMap.get(listener);
+      if (stored) {
+        if (attached) {
+          try {
+            IAP.instance.removePurchaseErrorListener(stored);
+          } catch {}
+        }
+        purchaseErrorListenerMap.delete(listener);
+      }
+    },
+  };
 };
+
+export const promotedProductListenerIOS = (
+  listener: (product: Product) => void,
+): EventSubscription => {
+  if (Platform.OS !== 'ios') {
+    console.warn(
+      'promotedProductListenerIOS: This listener is only available on iOS',
+    );
+    return {remove: () => {}};
+  }
+
+  const wrappedListener: NitroPromotedProductListener = (nitroProduct) => {
+    if (validateNitroProduct(nitroProduct)) {
+      const convertedProduct = convertNitroProductToProduct(nitroProduct);
+      listener(convertedProduct);
+    } else {
+      console.error(
+        'Invalid promoted product data received from native:',
+        nitroProduct,
+      );
+    }
+  };
+
+  promotedProductListenerMap.set(listener, wrappedListener);
+  let attached = false;
+  try {
+    IAP.instance.addPromotedProductListenerIOS(wrappedListener);
+    attached = true;
+  } catch (e) {
+    const msg = toErrorMessage(e);
+    if (msg.includes('Nitro runtime not installed')) {
+      console.warn(
+        '[promotedProductListenerIOS] Nitro not ready yet; listener inert until initConnection()',
+      );
+    } else {
+      throw e;
+    }
+  }
+
+  return {
+    remove: () => {
+      const wrapped = promotedProductListenerMap.get(listener);
+      if (wrapped) {
+        if (attached) {
+          try {
+            IAP.instance.removePromotedProductListenerIOS(wrapped);
+          } catch {}
+        }
+        promotedProductListenerMap.delete(listener);
+      }
+    },
+  };
+};
+
+// ------------------------------
+// Query API
+// ------------------------------
 
 /**
  * Fetch products from the store
@@ -260,47 +305,52 @@ export const endConnection = async (): Promise<boolean> => {
  * const subscriptions = await fetchProducts({ skus: ['sub1', 'sub2'], type: 'subs' });
  * ```
  */
-export const fetchProducts = async ({
-  skus,
-  type = 'in-app',
-}: ProductRequest): Promise<Product[]> => {
+export const fetchProducts: QueryField<'fetchProducts'> = async (request) => {
+  const {skus, type} = request;
+
   try {
-    if (!skus || skus.length === 0) {
+    if (!skus?.length) {
       throw new Error('No SKUs provided');
     }
 
     const normalizedType = normalizeProductQueryType(type);
 
-    if (normalizedType === 'all') {
-      const [inappNitro, subsNitro] = await Promise.all([
-        IAP.instance.fetchProducts(skus, 'inapp'),
-        IAP.instance.fetchProducts(skus, 'subs'),
-      ]);
-      const allNitro = [...inappNitro, ...subsNitro];
-      const validAll = allNitro.filter(validateNitroProduct);
-      if (validAll.length !== allNitro.length) {
+    const fetchAndConvert = async (
+      nitroType: ReturnType<typeof toNitroProductType> | 'all',
+    ) => {
+      const nitroProducts = await IAP.instance.fetchProducts(skus, nitroType);
+      const validProducts = nitroProducts.filter(validateNitroProduct);
+      if (validProducts.length !== nitroProducts.length) {
         console.warn(
-          `[fetchProducts] Some products failed validation: ${allNitro.length - validAll.length} invalid`,
+          `[fetchProducts] Some products failed validation: ${nitroProducts.length - validProducts.length} invalid`,
         );
       }
-      return validAll.map(convertNitroProductToProduct);
+      return validProducts.map(convertNitroProductToProduct);
+    };
+
+    if (normalizedType === 'all') {
+      const converted = await fetchAndConvert('all');
+      const productItems = converted.filter(
+        (item): item is Product => item.type === 'in-app',
+      );
+      const subscriptionItems = converted
+        .filter((item) => item.type === 'subs')
+        .map(convertProductToProductSubscription);
+
+      return [...productItems, ...subscriptionItems] as FetchProductsResult;
     }
 
-    const nitroProducts = await IAP.instance.fetchProducts(
-      skus,
+    const convertedProducts = await fetchAndConvert(
       toNitroProductType(normalizedType),
     );
 
-    // Validate and convert NitroProducts to TypeScript Products
-    const validProducts = nitroProducts.filter(validateNitroProduct);
-    if (validProducts.length !== nitroProducts.length) {
-      console.warn(
-        `[fetchProducts] Some products failed validation: ${nitroProducts.length - validProducts.length} invalid`,
-      );
+    if (normalizedType === 'subs') {
+      return convertedProducts.map(
+        convertProductToProductSubscription,
+      ) as FetchProductsResult;
     }
 
-    const typedProducts = validProducts.map(convertNitroProductToProduct);
-    return typedProducts;
+    return convertedProducts as FetchProductsResult;
   } catch (error) {
     console.error('[fetchProducts] Failed:', error);
     throw error;
@@ -308,68 +358,375 @@ export const fetchProducts = async ({
 };
 
 /**
- * Request a purchase for products or subscriptions
- * @param params - Purchase request configuration
- * @param params.request - Platform-specific purchase parameters
- * @param params.type - Type of purchase: 'in-app' for products (default) or 'subs' for subscriptions
+ * Get available purchases (purchased items not yet consumed/finished)
+ * @param params - Options for getting available purchases
+ * @param params.alsoPublishToEventListener - Whether to also publish to event listener
+ * @param params.onlyIncludeActiveItems - Whether to only include active items
  *
  * @example
  * ```typescript
- * // Product purchase
- * await requestPurchase({
- *   request: {
- *     ios: { sku: productId },
- *     android: { skus: [productId] }
- *   },
- *   type: 'in-app'
- * });
- *
- * // Subscription purchase
- * await requestPurchase({
- *   request: {
- *     ios: { sku: subscriptionId },
- *     android: {
- *       skus: [subscriptionId],
- *       subscriptionOffers: [{ sku: subscriptionId, offerToken: 'token' }]
- *     }
- *   },
- *   type: 'subs'
+ * const purchases = await getAvailablePurchases({
+ *   onlyIncludeActiveItemsIOS: true
  * });
  * ```
  */
+export const getAvailablePurchases: QueryField<
+  'getAvailablePurchases'
+> = async (options) => {
+  const alsoPublishToEventListenerIOS = Boolean(
+    options?.alsoPublishToEventListenerIOS ?? false,
+  );
+  const onlyIncludeActiveItemsIOS = Boolean(
+    options?.onlyIncludeActiveItemsIOS ?? true,
+  );
+  try {
+    if (Platform.OS === 'ios') {
+      const nitroOptions: NitroAvailablePurchasesOptions = {
+        ios: {
+          alsoPublishToEventListenerIOS,
+          onlyIncludeActiveItemsIOS,
+          alsoPublishToEventListener: alsoPublishToEventListenerIOS,
+          onlyIncludeActiveItems: onlyIncludeActiveItemsIOS,
+        },
+      };
+      const nitroPurchases =
+        await IAP.instance.getAvailablePurchases(nitroOptions);
+
+      const validPurchases = nitroPurchases.filter(validateNitroPurchase);
+      if (validPurchases.length !== nitroPurchases.length) {
+        console.warn(
+          `[getAvailablePurchases] Some purchases failed validation: ${nitroPurchases.length - validPurchases.length} invalid`,
+        );
+      }
+
+      return validPurchases.map(convertNitroPurchaseToPurchase);
+    } else if (Platform.OS === 'android') {
+      // For Android, we need to call twice for inapp and subs
+      const inappNitroPurchases = await IAP.instance.getAvailablePurchases({
+        android: {type: 'inapp'},
+      });
+      const subsNitroPurchases = await IAP.instance.getAvailablePurchases({
+        android: {type: 'subs'},
+      });
+
+      // Validate and convert both sets of purchases
+      const allNitroPurchases = [...inappNitroPurchases, ...subsNitroPurchases];
+      const validPurchases = allNitroPurchases.filter(validateNitroPurchase);
+      if (validPurchases.length !== allNitroPurchases.length) {
+        console.warn(
+          `[getAvailablePurchases] Some Android purchases failed validation: ${allNitroPurchases.length - validPurchases.length} invalid`,
+        );
+      }
+
+      return validPurchases.map(convertNitroPurchaseToPurchase);
+    } else {
+      throw new Error('Unsupported platform');
+    }
+  } catch (error) {
+    console.error('Failed to get available purchases:', error);
+    throw error;
+  }
+};
+
+/**
+ * Request the promoted product from the App Store (iOS only)
+ * @returns Promise<Product | null> - The promoted product or null if none available
+ * @platform iOS
+ */
+export const getPromotedProductIOS: QueryField<
+  'getPromotedProductIOS'
+> = async () => {
+  if (Platform.OS !== 'ios') {
+    return null;
+  }
+
+  try {
+    const nitroProduct = await IAP.instance.requestPromotedProductIOS();
+    if (!nitroProduct) {
+      return null;
+    }
+    const converted = convertNitroProductToProduct(nitroProduct);
+    return converted.platform === 'ios' ? (converted as ProductIOS) : null;
+  } catch (error) {
+    console.error('[getPromotedProductIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const requestPromotedProductIOS = getPromotedProductIOS;
+
+export const getStorefrontIOS: QueryField<'getStorefrontIOS'> = async () => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('getStorefrontIOS is only available on iOS');
+  }
+
+  try {
+    const storefront = await IAP.instance.getStorefrontIOS();
+    return storefront;
+  } catch (error) {
+    console.error('Failed to get storefront:', error);
+    throw error;
+  }
+};
+
+export const getAppTransactionIOS: QueryField<
+  'getAppTransactionIOS'
+> = async () => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('getAppTransactionIOS is only available on iOS');
+  }
+
+  try {
+    const appTransaction = await IAP.instance.getAppTransactionIOS();
+    return appTransaction;
+  } catch (error) {
+    console.error('Failed to get app transaction:', error);
+    throw error;
+  }
+};
+
+export const subscriptionStatusIOS: QueryField<
+  'subscriptionStatusIOS'
+> = async (sku) => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('subscriptionStatusIOS is only available on iOS');
+  }
+
+  try {
+    const statuses = await IAP.instance.subscriptionStatusIOS(sku);
+    if (!Array.isArray(statuses)) return [];
+    return statuses
+      .filter((status): status is NitroSubscriptionStatus => status != null)
+      .map(convertNitroSubscriptionStatusToSubscriptionStatusIOS);
+  } catch (error) {
+    console.error('[subscriptionStatusIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const currentEntitlementIOS: QueryField<
+  'currentEntitlementIOS'
+> = async (sku) => {
+  if (Platform.OS !== 'ios') {
+    return null;
+  }
+
+  try {
+    const nitroPurchase = await IAP.instance.currentEntitlementIOS(sku);
+    if (nitroPurchase) {
+      const converted = convertNitroPurchaseToPurchase(nitroPurchase);
+      return converted.platform === 'ios' ? (converted as PurchaseIOS) : null;
+    }
+    return null;
+  } catch (error) {
+    console.error('[currentEntitlementIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const latestTransactionIOS: QueryField<'latestTransactionIOS'> = async (
+  sku,
+) => {
+  if (Platform.OS !== 'ios') {
+    return null;
+  }
+
+  try {
+    const nitroPurchase = await IAP.instance.latestTransactionIOS(sku);
+    if (nitroPurchase) {
+      const converted = convertNitroPurchaseToPurchase(nitroPurchase);
+      return converted.platform === 'ios' ? (converted as PurchaseIOS) : null;
+    }
+    return null;
+  } catch (error) {
+    console.error('[latestTransactionIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const getPendingTransactionsIOS: QueryField<
+  'getPendingTransactionsIOS'
+> = async () => {
+  if (Platform.OS !== 'ios') {
+    return [];
+  }
+
+  try {
+    const nitroPurchases = await IAP.instance.getPendingTransactionsIOS();
+    return nitroPurchases
+      .map(convertNitroPurchaseToPurchase)
+      .filter(
+        (purchase): purchase is PurchaseIOS => purchase.platform === 'ios',
+      );
+  } catch (error) {
+    console.error('[getPendingTransactionsIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const showManageSubscriptionsIOS: MutationField<
+  'showManageSubscriptionsIOS'
+> = async () => {
+  if (Platform.OS !== 'ios') {
+    return [];
+  }
+
+  try {
+    const nitroPurchases = await IAP.instance.showManageSubscriptionsIOS();
+    return nitroPurchases
+      .map(convertNitroPurchaseToPurchase)
+      .filter(
+        (purchase): purchase is PurchaseIOS => purchase.platform === 'ios',
+      );
+  } catch (error) {
+    console.error('[showManageSubscriptionsIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const isEligibleForIntroOfferIOS: QueryField<
+  'isEligibleForIntroOfferIOS'
+> = async (groupID) => {
+  if (Platform.OS !== 'ios') {
+    return false;
+  }
+
+  try {
+    return await IAP.instance.isEligibleForIntroOfferIOS(groupID);
+  } catch (error) {
+    console.error('[isEligibleForIntroOfferIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const getReceiptDataIOS: QueryField<'getReceiptDataIOS'> = async () => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('getReceiptDataIOS is only available on iOS');
+  }
+
+  try {
+    return await IAP.instance.getReceiptDataIOS();
+  } catch (error) {
+    console.error('[getReceiptDataIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const isTransactionVerifiedIOS: QueryField<
+  'isTransactionVerifiedIOS'
+> = async (sku) => {
+  if (Platform.OS !== 'ios') {
+    return false;
+  }
+
+  try {
+    return await IAP.instance.isTransactionVerifiedIOS(sku);
+  } catch (error) {
+    console.error('[isTransactionVerifiedIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+export const getTransactionJwsIOS: QueryField<'getTransactionJwsIOS'> = async (
+  sku,
+) => {
+  if (Platform.OS !== 'ios') {
+    return null;
+  }
+
+  try {
+    return await IAP.instance.getTransactionJwsIOS(sku);
+  } catch (error) {
+    console.error('[getTransactionJwsIOS] Failed:', error);
+    const errorJson = parseErrorStringToJsonObj(error);
+    throw new Error(errorJson.message);
+  }
+};
+
+// ------------------------------
+// Mutation API
+// ------------------------------
+
+/**
+ * Initialize connection to the store
+ */
+export const initConnection: MutationField<'initConnection'> = async () => {
+  try {
+    return await IAP.instance.initConnection();
+  } catch (error) {
+    console.error('Failed to initialize IAP connection:', error);
+    throw error;
+  }
+};
+
+/**
+ * End connection to the store
+ */
+export const endConnection: MutationField<'endConnection'> = async () => {
+  try {
+    if (!iapRef) return true;
+    return await IAP.instance.endConnection();
+  } catch (error) {
+    console.error('Failed to end IAP connection:', error);
+    throw error;
+  }
+};
+
+export const restorePurchases: MutationField<'restorePurchases'> = async () => {
+  try {
+    if (Platform.OS === 'ios') {
+      await syncIOS();
+    }
+
+    await getAvailablePurchases({
+      alsoPublishToEventListenerIOS: false,
+      onlyIncludeActiveItemsIOS: true,
+    });
+  } catch (error) {
+    console.error('Failed to restore purchases:', error);
+    throw error;
+  }
+};
+
 /**
  * Request a purchase for products or subscriptions
  * ⚠️ Important: This is an event-based operation, not promise-based.
  * Listen for events through purchaseUpdatedListener or purchaseErrorListener.
- * @param params - Purchase request configuration
- * @param params.request - Platform-specific request parameters
- * @param params.type - Type of purchase (defaults to in-app)
  */
-export const requestPurchase = async (
-  params: RequestPurchaseProps,
-): Promise<RequestPurchaseResult> => {
+export const requestPurchase: MutationField<'requestPurchase'> = async (
+  request,
+) => {
   try {
-    const normalizedType = normalizeProductQueryType(params.type);
+    const {request: platformRequest, type} = request;
+    const normalizedType = normalizeProductQueryType(type ?? 'in-app');
     const isSubs = isSubscriptionQuery(normalizedType);
-    const request = params.request as
+    const perPlatformRequest = platformRequest as
       | RequestPurchasePropsByPlatforms
       | RequestSubscriptionPropsByPlatforms
       | undefined;
 
-    if (!request) {
+    if (!perPlatformRequest) {
       throw new Error('Missing purchase request configuration');
     }
 
-    // Validate platform-specific requests
     if (Platform.OS === 'ios') {
-      const iosRequest = request.ios;
+      const iosRequest = perPlatformRequest.ios;
       if (!iosRequest?.sku) {
         throw new Error(
           'Invalid request for iOS. The `sku` property is required.',
         );
       }
     } else if (Platform.OS === 'android') {
-      const androidRequest = request.android;
+      const androidRequest = perPlatformRequest.android;
       if (!androidRequest?.skus?.length) {
         throw new Error(
           'Invalid request for Android. The `skus` property is required and must be a non-empty array.',
@@ -381,10 +738,10 @@ export const requestPurchase = async (
 
     const unifiedRequest: NitroPurchaseRequest = {};
 
-    if (Platform.OS === 'ios' && request.ios) {
+    if (Platform.OS === 'ios' && perPlatformRequest.ios) {
       const iosRequest = isSubs
-        ? (request.ios as RequestSubscriptionIosProps)
-        : (request.ios as RequestPurchaseIosProps);
+        ? (perPlatformRequest.ios as RequestSubscriptionIosProps)
+        : (perPlatformRequest.ios as RequestPurchaseIosProps);
 
       const iosPayload: NonNullable<NitroPurchaseRequest['ios']> = {
         sku: iosRequest.sku,
@@ -415,10 +772,10 @@ export const requestPurchase = async (
       unifiedRequest.ios = iosPayload;
     }
 
-    if (Platform.OS === 'android' && request.android) {
+    if (Platform.OS === 'android' && perPlatformRequest.android) {
       const androidRequest = isSubs
-        ? (request.android as RequestSubscriptionAndroidProps)
-        : (request.android as RequestPurchaseAndroidProps);
+        ? (perPlatformRequest.android as RequestSubscriptionAndroidProps)
+        : (perPlatformRequest.android as RequestPurchaseAndroidProps);
 
       const androidPayload: NonNullable<NitroPurchaseRequest['android']> = {
         skus: androidRequest.skus,
@@ -469,77 +826,11 @@ export const requestPurchase = async (
 };
 
 /**
- * Get available purchases (purchased items not yet consumed/finished)
- * @param params - Options for getting available purchases
- * @param params.alsoPublishToEventListener - Whether to also publish to event listener
- * @param params.onlyIncludeActiveItems - Whether to only include active items
- *
- * @example
- * ```typescript
- * const purchases = await getAvailablePurchases({
- *   onlyIncludeActiveItemsIOS: true
- * });
- * ```
- */
-export const getAvailablePurchases = async ({
-  alsoPublishToEventListenerIOS = false,
-  onlyIncludeActiveItemsIOS = true,
-}: PurchaseOptions = {}): Promise<Purchase[]> => {
-  try {
-    if (Platform.OS === 'ios') {
-      const iosAlsoPublish = Boolean(alsoPublishToEventListenerIOS);
-      const iosOnlyActive = Boolean(onlyIncludeActiveItemsIOS);
-      const options: NitroAvailablePurchasesOptions = {
-        ios: {
-          alsoPublishToEventListenerIOS: iosAlsoPublish,
-          onlyIncludeActiveItemsIOS: iosOnlyActive,
-          alsoPublishToEventListener: iosAlsoPublish,
-          onlyIncludeActiveItems: iosOnlyActive,
-        },
-      };
-      const nitroPurchases = await IAP.instance.getAvailablePurchases(options);
-
-      const validPurchases = nitroPurchases.filter(validateNitroPurchase);
-      if (validPurchases.length !== nitroPurchases.length) {
-        console.warn(
-          `[getAvailablePurchases] Some purchases failed validation: ${nitroPurchases.length - validPurchases.length} invalid`,
-        );
-      }
-
-      return validPurchases.map(convertNitroPurchaseToPurchase);
-    } else if (Platform.OS === 'android') {
-      // For Android, we need to call twice for inapp and subs
-      const inappNitroPurchases = await IAP.instance.getAvailablePurchases({
-        android: {type: 'inapp'},
-      });
-      const subsNitroPurchases = await IAP.instance.getAvailablePurchases({
-        android: {type: 'subs'},
-      });
-
-      // Validate and convert both sets of purchases
-      const allNitroPurchases = [...inappNitroPurchases, ...subsNitroPurchases];
-      const validPurchases = allNitroPurchases.filter(validateNitroPurchase);
-      if (validPurchases.length !== allNitroPurchases.length) {
-        console.warn(
-          `[getAvailablePurchases] Some Android purchases failed validation: ${allNitroPurchases.length - validPurchases.length} invalid`,
-        );
-      }
-
-      return validPurchases.map(convertNitroPurchaseToPurchase);
-    } else {
-      throw new Error('Unsupported platform');
-    }
-  } catch (error) {
-    console.error('Failed to get available purchases:', error);
-    throw error;
-  }
-};
-
-/**
  * Finish a transaction (consume or acknowledge)
  * @param params - Transaction finish parameters
  * @param params.purchase - The purchase to finish
  * @param params.isConsumable - Whether this is a consumable product (Android only)
+ * @returns Promise<void> - Resolves when the transaction is successfully finished
  *
  * @example
  * ```typescript
@@ -549,10 +840,10 @@ export const getAvailablePurchases = async ({
  * });
  * ```
  */
-export const finishTransaction = async ({
-  purchase,
-  isConsumable = false,
-}: FinishTransactionParams): Promise<NitroPurchaseResult | boolean> => {
+export const finishTransaction: MutationField<'finishTransaction'> = async (
+  args,
+) => {
+  const {purchase, isConsumable} = args;
   try {
     let params: NitroFinishTransactionParamsInternal;
     if (Platform.OS === 'ios') {
@@ -565,8 +856,7 @@ export const finishTransaction = async ({
         },
       };
     } else if (Platform.OS === 'android') {
-      const androidPurchase = purchase as PurchaseAndroid;
-      const token = androidPurchase.purchaseToken;
+      const token = purchase.purchaseToken ?? undefined;
 
       if (!token) {
         throw new Error('purchaseToken required to finish Android transaction');
@@ -575,7 +865,7 @@ export const finishTransaction = async ({
       params = {
         android: {
           purchaseToken: token,
-          isConsumable,
+          isConsumable: isConsumable ?? false,
         },
       };
     } else {
@@ -583,13 +873,11 @@ export const finishTransaction = async ({
     }
 
     const result = await IAP.instance.finishTransaction(params);
-
-    // Handle variant return type
-    if (typeof result === 'boolean') {
-      return result;
+    const success = getSuccessFromPurchaseVariant(result, 'finishTransaction');
+    if (!success) {
+      throw new Error('Failed to finish transaction');
     }
-    // It's a PurchaseResult
-    return result as NitroPurchaseResult;
+    return;
   } catch (error) {
     // If iOS transaction has already been auto-finished natively, treat as success
     if (Platform.OS === 'ios') {
@@ -601,7 +889,7 @@ export const finishTransaction = async ({
         code === 'E_ITEM_UNAVAILABLE'
       ) {
         // Consider already finished
-        return true;
+        return;
       }
     }
     console.error('Failed to finish transaction:', error);
@@ -612,15 +900,16 @@ export const finishTransaction = async ({
 /**
  * Acknowledge a purchase (Android only)
  * @param purchaseToken - The purchase token to acknowledge
+ * @returns Promise<boolean> - Indicates whether the acknowledgement succeeded
  *
  * @example
  * ```typescript
  * await acknowledgePurchaseAndroid('purchase_token_here');
  * ```
  */
-export const acknowledgePurchaseAndroid = async (
-  purchaseToken: string,
-): Promise<NitroPurchaseResult> => {
+export const acknowledgePurchaseAndroid: MutationField<
+  'acknowledgePurchaseAndroid'
+> = async (purchaseToken) => {
   try {
     if (Platform.OS !== 'android') {
       throw new Error(
@@ -634,18 +923,7 @@ export const acknowledgePurchaseAndroid = async (
         isConsumable: false,
       },
     });
-
-    // Result is a variant, extract PurchaseResult
-    if (typeof result === 'boolean') {
-      // This shouldn't happen for Android, but handle it
-      return {
-        responseCode: 0,
-        code: '0',
-        message: 'Success',
-        purchaseToken,
-      };
-    }
-    return result as NitroPurchaseResult;
+    return getSuccessFromPurchaseVariant(result, 'acknowledgePurchaseAndroid');
   } catch (error) {
     console.error('Failed to acknowledge purchase Android:', error);
     throw error;
@@ -655,15 +933,16 @@ export const acknowledgePurchaseAndroid = async (
 /**
  * Consume a purchase (Android only)
  * @param purchaseToken - The purchase token to consume
+ * @returns Promise<boolean> - Indicates whether the consumption succeeded
  *
  * @example
  * ```typescript
  * await consumePurchaseAndroid('purchase_token_here');
  * ```
  */
-export const consumePurchaseAndroid = async (
-  purchaseToken: string,
-): Promise<NitroPurchaseResult> => {
+export const consumePurchaseAndroid: MutationField<
+  'consumePurchaseAndroid'
+> = async (purchaseToken) => {
   try {
     if (Platform.OS !== 'android') {
       throw new Error('consumePurchaseAndroid is only available on Android');
@@ -675,252 +954,11 @@ export const consumePurchaseAndroid = async (
         isConsumable: true,
       },
     });
-
-    // Result is a variant, extract PurchaseResult
-    if (typeof result === 'boolean') {
-      // This shouldn't happen for Android, but handle it
-      return {
-        responseCode: 0,
-        code: '0',
-        message: 'Success',
-        purchaseToken,
-      };
-    }
-    return result as NitroPurchaseResult;
+    return getSuccessFromPurchaseVariant(result, 'consumePurchaseAndroid');
   } catch (error) {
     console.error('Failed to consume purchase Android:', error);
     throw error;
   }
-};
-
-// ============================================================================
-// EVENT LISTENERS
-// ============================================================================
-
-// Store wrapped listeners for proper removal
-const purchaseUpdatedListenerMap = new WeakMap<
-  (purchase: Purchase) => void,
-  NitroPurchaseListener
->();
-const purchaseErrorListenerMap = new WeakMap<
-  (error: PurchaseError) => void,
-  NitroPurchaseErrorListener
->();
-const promotedProductListenerMap = new WeakMap<
-  (product: Product) => void,
-  NitroPromotedProductListener
->();
-
-/**
- * Purchase updated event listener
- * Fired when a purchase is successful or when a pending purchase is completed.
- *
- * @param listener - Function to call when a purchase is updated
- * @returns EventSubscription object with remove method
- *
- * @example
- * ```typescript
- * const subscription = purchaseUpdatedListener((purchase) => {
- *   console.log('Purchase successful:', purchase);
- *   // 1. Validate receipt with backend
- *   // 2. Deliver content to user
- *   // 3. Call finishTransaction to acknowledge
- * });
- *
- * // Later, clean up
- * subscription.remove();
- * ```
- */
-export const purchaseUpdatedListener = (
-  listener: (purchase: Purchase) => void,
-): EventSubscription => {
-  // Wrap the listener to convert NitroPurchase to Purchase
-  const wrappedListener: NitroPurchaseListener = (nitroPurchase) => {
-    if (validateNitroPurchase(nitroPurchase)) {
-      const convertedPurchase = convertNitroPurchaseToPurchase(nitroPurchase);
-      listener(convertedPurchase);
-    } else {
-      console.error(
-        'Invalid purchase data received from native:',
-        nitroPurchase,
-      );
-    }
-  };
-
-  // Store the wrapped listener for removal
-  purchaseUpdatedListenerMap.set(listener, wrappedListener);
-  let attached = false;
-  try {
-    IAP.instance.addPurchaseUpdatedListener(wrappedListener);
-    attached = true;
-  } catch (e) {
-    const msg = toErrorMessage(e);
-    if (msg.includes('Nitro runtime not installed')) {
-      console.warn(
-        '[purchaseUpdatedListener] Nitro not ready yet; listener inert until initConnection()',
-      );
-    } else {
-      throw e;
-    }
-  }
-
-  return {
-    remove: () => {
-      const wrapped = purchaseUpdatedListenerMap.get(listener);
-      if (wrapped) {
-        if (attached) {
-          try {
-            IAP.instance.removePurchaseUpdatedListener(wrapped);
-          } catch {}
-        }
-        purchaseUpdatedListenerMap.delete(listener);
-      }
-    },
-  };
-};
-
-/**
- * Purchase error event listener
- * Fired when a purchase fails or is cancelled by the user.
- *
- * @param listener - Function to call when a purchase error occurs
- * @returns EventSubscription object with remove method
- *
- * @example
- * ```typescript
- * const subscription = purchaseErrorListener((error) => {
- *   switch (error.code) {
- *     case 'E_USER_CANCELLED':
- *       // User cancelled - no action needed
- *       break;
- *     case 'E_ITEM_UNAVAILABLE':
- *       // Product not available
- *       break;
- *     case 'E_NETWORK_ERROR':
- *       // Retry with backoff
- *       break;
- *   }
- * });
- *
- * // Later, clean up
- * subscription.remove();
- * ```
- */
-export const purchaseErrorListener = (
-  listener: (error: PurchaseError) => void,
-): EventSubscription => {
-  const wrapped: NitroPurchaseErrorListener = (error) => {
-    listener({
-      code: normalizeErrorCodeFromNative(error.code),
-      message: error.message,
-      productId: undefined,
-    });
-  };
-
-  purchaseErrorListenerMap.set(listener, wrapped);
-  let attached = false;
-  try {
-    IAP.instance.addPurchaseErrorListener(wrapped);
-    attached = true;
-  } catch (e) {
-    const msg = toErrorMessage(e);
-    if (msg.includes('Nitro runtime not installed')) {
-      console.warn(
-        '[purchaseErrorListener] Nitro not ready yet; listener inert until initConnection()',
-      );
-    } else {
-      throw e;
-    }
-  }
-
-  return {
-    remove: () => {
-      const stored = purchaseErrorListenerMap.get(listener);
-      if (stored) {
-        if (attached) {
-          try {
-            IAP.instance.removePurchaseErrorListener(stored);
-          } catch {}
-        }
-        purchaseErrorListenerMap.delete(listener);
-      }
-    },
-  };
-};
-
-/**
- * iOS-only listener for App Store promoted product events.
- * Fired when a user clicks on a promoted in-app purchase in the App Store.
- *
- * @param listener - Callback function that receives the promoted product
- * @returns EventSubscription object with remove method
- *
- * @example
- * ```typescript
- * const subscription = promotedProductListenerIOS((product) => {
- *   console.log('Promoted product:', product);
- *   // Trigger purchase flow for the promoted product
- * });
- *
- * // Later, clean up
- * subscription.remove();
- * ```
- *
- * @platform iOS
- */
-export const promotedProductListenerIOS = (
-  listener: (product: Product) => void,
-): EventSubscription => {
-  if (Platform.OS !== 'ios') {
-    console.warn(
-      'promotedProductListenerIOS: This listener is only available on iOS',
-    );
-    return {remove: () => {}};
-  }
-
-  // Wrap the listener to convert NitroProduct to Product
-  const wrappedListener: NitroPromotedProductListener = (nitroProduct) => {
-    if (validateNitroProduct(nitroProduct)) {
-      const convertedProduct = convertNitroProductToProduct(nitroProduct);
-      listener(convertedProduct);
-    } else {
-      console.error(
-        'Invalid promoted product data received from native:',
-        nitroProduct,
-      );
-    }
-  };
-
-  // Store the wrapped listener for removal
-  promotedProductListenerMap.set(listener, wrappedListener);
-  let attached = false;
-  try {
-    IAP.instance.addPromotedProductListenerIOS(wrappedListener);
-    attached = true;
-  } catch (e) {
-    const msg = toErrorMessage(e);
-    if (msg.includes('Nitro runtime not installed')) {
-      console.warn(
-        '[promotedProductListenerIOS] Nitro not ready yet; listener inert until initConnection()',
-      );
-    } else {
-      throw e;
-    }
-  }
-
-  return {
-    remove: () => {
-      const wrapped = promotedProductListenerMap.get(listener);
-      if (wrapped) {
-        if (attached) {
-          try {
-            IAP.instance.removePromotedProductListenerIOS(wrapped);
-          } catch {}
-        }
-        promotedProductListenerMap.delete(listener);
-      }
-    },
-  };
 };
 
 // ============================================================================
@@ -933,19 +971,25 @@ export const promotedProductListenerIOS = (
  * @param androidOptions - Android-specific validation options (required for Android)
  * @returns Promise<ReceiptValidationResultIOS | ReceiptValidationResultAndroid> - Platform-specific receipt validation result
  */
-export const validateReceipt = async (
-  sku: string,
-  androidOptions?: {
-    packageName: string;
-    productToken: string;
-    accessToken: string;
-    isSub?: boolean;
-  },
-): Promise<import('./types').ReceiptValidationResult> => {
+export const validateReceipt: MutationField<'validateReceipt'> = async (
+  options,
+) => {
+  const {sku, androidOptions} = options;
   try {
+    const normalizedAndroidOptions =
+      androidOptions != null
+        ? {
+            ...androidOptions,
+            isSub:
+              androidOptions.isSub == null
+                ? undefined
+                : Boolean(androidOptions.isSub),
+          }
+        : undefined;
+
     const params: NitroReceiptValidationParams = {
       sku,
-      androidOptions,
+      androidOptions: normalizedAndroidOptions,
     };
 
     const nitroResult = await IAP.instance.validateReceipt(params);
@@ -999,13 +1043,14 @@ export const validateReceipt = async (
  * @returns Promise<boolean>
  * @platform iOS
  */
-export const syncIOS = async (): Promise<boolean> => {
+export const syncIOS: MutationField<'syncIOS'> = async () => {
   if (Platform.OS !== 'ios') {
     throw new Error('syncIOS is only available on iOS');
   }
 
   try {
-    return await IAP.instance.syncIOS();
+    const result = await IAP.instance.syncIOS();
+    return Boolean(result);
   } catch (error) {
     console.error('[syncIOS] Failed:', error);
     const errorJson = parseErrorStringToJsonObj(error);
@@ -1014,40 +1059,20 @@ export const syncIOS = async (): Promise<boolean> => {
 };
 
 /**
- * Request the promoted product from the App Store (iOS only)
- * @returns Promise<Product | null> - The promoted product or null if none available
- * @platform iOS
- */
-export const requestPromotedProductIOS = async (): Promise<Product | null> => {
-  if (Platform.OS !== 'ios') {
-    return null;
-  }
-
-  try {
-    const nitroProduct = await IAP.instance.requestPromotedProductIOS();
-    if (nitroProduct) {
-      return convertNitroProductToProduct(nitroProduct);
-    }
-    return null;
-  } catch (error) {
-    console.error('[getPromotedProductIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
-/**
  * Present the code redemption sheet for offer codes (iOS only)
- * @returns Promise<boolean> - True if the sheet was presented successfully
+ * @returns Promise<boolean> - Indicates whether the redemption sheet was presented
  * @platform iOS
  */
-export const presentCodeRedemptionSheetIOS = async (): Promise<boolean> => {
+export const presentCodeRedemptionSheetIOS: MutationField<
+  'presentCodeRedemptionSheetIOS'
+> = async () => {
   if (Platform.OS !== 'ios') {
     return false;
   }
 
   try {
-    return await IAP.instance.presentCodeRedemptionSheetIOS();
+    const result = await IAP.instance.presentCodeRedemptionSheetIOS();
+    return Boolean(result);
   } catch (error) {
     console.error('[presentCodeRedemptionSheetIOS] Failed:', error);
     const errorJson = parseErrorStringToJsonObj(error);
@@ -1060,32 +1085,50 @@ export const presentCodeRedemptionSheetIOS = async (): Promise<boolean> => {
  * @returns Promise<void>
  * @platform iOS
  */
-export const buyPromotedProductIOS = async (): Promise<void> => {
+export const requestPurchaseOnPromotedProductIOS: MutationField<
+  'requestPurchaseOnPromotedProductIOS'
+> = async () => {
   if (Platform.OS !== 'ios') {
-    throw new Error('buyPromotedProductIOS is only available on iOS');
+    throw new Error(
+      'requestPurchaseOnPromotedProductIOS is only available on iOS',
+    );
   }
 
   try {
     await IAP.instance.buyPromotedProductIOS();
+    const pending = await IAP.instance.getPendingTransactionsIOS();
+    const latest = pending.find((purchase) => purchase != null);
+    if (!latest) {
+      throw new Error('No promoted purchase available after request');
+    }
+
+    const converted = convertNitroPurchaseToPurchase(latest);
+    if (converted.platform !== 'ios') {
+      throw new Error('Promoted purchase result not available for iOS');
+    }
+
+    return converted as PurchaseIOS;
   } catch (error) {
-    console.error('[buyPromotedProductIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
+    console.error('[requestPurchaseOnPromotedProductIOS] Failed:', error);
+    throw error;
   }
 };
 
 /**
  * Clear unfinished transactions on iOS
- * @returns Promise<void>
+ * @returns Promise<boolean>
  * @platform iOS
  */
-export const clearTransactionIOS = async (): Promise<void> => {
+export const clearTransactionIOS: MutationField<
+  'clearTransactionIOS'
+> = async () => {
   if (Platform.OS !== 'ios') {
-    return;
+    return false;
   }
 
   try {
     await IAP.instance.clearTransactionIOS();
+    return true;
   } catch (error) {
     console.error('[clearTransactionIOS] Failed:', error);
     const errorJson = parseErrorStringToJsonObj(error);
@@ -1099,15 +1142,16 @@ export const clearTransactionIOS = async (): Promise<void> => {
  * @returns Promise<string | null> - The refund status or null if not available
  * @platform iOS
  */
-export const beginRefundRequestIOS = async (
-  sku: string,
-): Promise<string | null> => {
+export const beginRefundRequestIOS: MutationField<
+  'beginRefundRequestIOS'
+> = async (sku) => {
   if (Platform.OS !== 'ios') {
-    return null;
+    throw new Error('beginRefundRequestIOS is only available on iOS');
   }
 
   try {
-    return await IAP.instance.beginRefundRequestIOS(sku);
+    const status = await IAP.instance.beginRefundRequestIOS(sku);
+    return status ?? null;
   } catch (error) {
     console.error('[beginRefundRequestIOS] Failed:', error);
     const errorJson = parseErrorStringToJsonObj(error);
@@ -1122,203 +1166,51 @@ export const beginRefundRequestIOS = async (
  * @throws Error when called on non-iOS platforms or when IAP is not initialized
  * @platform iOS
  */
-export const subscriptionStatusIOS = async (
-  sku: string,
-): Promise<SubscriptionStatusIOS[]> => {
-  if (Platform.OS !== 'ios') {
-    throw new Error('subscriptionStatusIOS is only available on iOS');
-  }
-
-  try {
-    const statuses = await IAP.instance.subscriptionStatusIOS(sku);
-    if (!Array.isArray(statuses)) return [];
-    return statuses
-      .filter((status): status is NitroSubscriptionStatus => status != null)
-      .map(convertNitroSubscriptionStatusToSubscriptionStatusIOS);
-  } catch (error) {
-    console.error('[subscriptionStatusIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Get current entitlement for a product (iOS only)
  * @param sku - The product SKU
  * @returns Promise<Purchase | null> - Current entitlement or null
  * @platform iOS
  */
-export const currentEntitlementIOS = async (
-  sku: string,
-): Promise<Purchase | null> => {
-  if (Platform.OS !== 'ios') {
-    return null;
-  }
-
-  try {
-    const nitroPurchase = await IAP.instance.currentEntitlementIOS(sku);
-    if (nitroPurchase) {
-      return convertNitroPurchaseToPurchase(nitroPurchase);
-    }
-    return null;
-  } catch (error) {
-    console.error('[currentEntitlementIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Get latest transaction for a product (iOS only)
  * @param sku - The product SKU
  * @returns Promise<Purchase | null> - Latest transaction or null
  * @platform iOS
  */
-export const latestTransactionIOS = async (
-  sku: string,
-): Promise<Purchase | null> => {
-  if (Platform.OS !== 'ios') {
-    return null;
-  }
-
-  try {
-    const nitroPurchase = await IAP.instance.latestTransactionIOS(sku);
-    if (nitroPurchase) {
-      return convertNitroPurchaseToPurchase(nitroPurchase);
-    }
-    return null;
-  } catch (error) {
-    console.error('[latestTransactionIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Get pending transactions (iOS only)
  * @returns Promise<Purchase[]> - Array of pending transactions
  * @platform iOS
  */
-export const getPendingTransactionsIOS = async (): Promise<Purchase[]> => {
-  if (Platform.OS !== 'ios') {
-    return [];
-  }
-
-  try {
-    const nitroPurchases = await IAP.instance.getPendingTransactionsIOS();
-    return nitroPurchases.map(convertNitroPurchaseToPurchase);
-  } catch (error) {
-    console.error('[getPendingTransactionsIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Show manage subscriptions screen (iOS only)
  * @returns Promise<Purchase[]> - Subscriptions where auto-renewal status changed
  * @platform iOS
  */
-export const showManageSubscriptionsIOS = async (): Promise<Purchase[]> => {
-  if (Platform.OS !== 'ios') {
-    return [];
-  }
-
-  try {
-    const nitroPurchases = await IAP.instance.showManageSubscriptionsIOS();
-    return nitroPurchases.map(convertNitroPurchaseToPurchase);
-  } catch (error) {
-    console.error('[showManageSubscriptionsIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Check if user is eligible for intro offer (iOS only)
  * @param groupID - The subscription group ID
  * @returns Promise<boolean> - Eligibility status
  * @platform iOS
  */
-export const isEligibleForIntroOfferIOS = async (
-  groupID: string,
-): Promise<boolean> => {
-  if (Platform.OS !== 'ios') {
-    return false;
-  }
-
-  try {
-    return await IAP.instance.isEligibleForIntroOfferIOS(groupID);
-  } catch (error) {
-    console.error('[isEligibleForIntroOfferIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Get receipt data (iOS only)
  * @returns Promise<string> - Base64 encoded receipt data
  * @platform iOS
  */
-export const getReceiptDataIOS = async (): Promise<string> => {
-  if (Platform.OS !== 'ios') {
-    throw new Error('getReceiptDataIOS is only available on iOS');
-  }
-
-  try {
-    return await IAP.instance.getReceiptDataIOS();
-  } catch (error) {
-    console.error('[getReceiptDataIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Check if transaction is verified (iOS only)
  * @param sku - The product SKU
  * @returns Promise<boolean> - Verification status
  * @platform iOS
  */
-export const isTransactionVerifiedIOS = async (
-  sku: string,
-): Promise<boolean> => {
-  if (Platform.OS !== 'ios') {
-    return false;
-  }
-
-  try {
-    return await IAP.instance.isTransactionVerifiedIOS(sku);
-  } catch (error) {
-    console.error('[isTransactionVerifiedIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Get transaction JWS representation (iOS only)
  * @param sku - The product SKU
  * @returns Promise<string | null> - JWS representation or null
  * @platform iOS
  */
-export const getTransactionJwsIOS = async (
-  sku: string,
-): Promise<string | null> => {
-  if (Platform.OS !== 'ios') {
-    return null;
-  }
-
-  try {
-    return await IAP.instance.getTransactionJwsIOS(sku);
-  } catch (error) {
-    console.error('[getTransactionJwsIOS] Failed:', error);
-    const errorJson = parseErrorStringToJsonObj(error);
-    throw new Error(errorJson.message);
-  }
-};
-
 /**
  * Get the storefront identifier for the user's App Store account (iOS only)
  * @returns Promise<string> - The storefront identifier (e.g., 'USA' for United States)
@@ -1330,67 +1222,29 @@ export const getTransactionJwsIOS = async (
  * console.log('User storefront:', storefront); // e.g., 'USA', 'GBR', 'KOR'
  * ```
  */
-export const getStorefrontIOS = async (): Promise<string> => {
-  if (Platform.OS !== 'ios') {
-    throw new Error('getStorefrontIOS is only available on iOS');
-  }
-
-  try {
-    // Call the native method to get storefront
-    const storefront = await IAP.instance.getStorefrontIOS();
-    return storefront;
-  } catch (error) {
-    console.error('Failed to get storefront:', error);
-    throw error;
-  }
-};
-
-/**
- * Gets the storefront country code from the underlying native store.
- * Returns a two-letter country code such as 'US', 'KR', or empty string on failure.
- *
- * Cross-platform alias aligning with expo-iap.
- */
-export const getStorefront = async (): Promise<string> => {
-  if (Platform.OS === 'android') {
-    try {
-      // Optional since older builds may not have the method
-      const result = await IAP.instance.getStorefrontAndroid?.();
-      return result ?? '';
-    } catch {
-      return '';
-    }
-  }
-  return getStorefrontIOS();
-};
-
 /**
  * Deeplinks to native interface that allows users to manage their subscriptions
  * Cross-platform alias aligning with expo-iap
  */
-export const deepLinkToSubscriptions = async (
-  options: {
-    skuAndroid?: string;
-    packageNameAndroid?: string;
-  } = {},
-): Promise<void> => {
+export const deepLinkToSubscriptions: MutationField<
+  'deepLinkToSubscriptions'
+> = async (options) => {
+  const resolvedOptions = options ?? undefined;
+
   if (Platform.OS === 'android') {
     await IAP.instance.deepLinkToSubscriptionsAndroid?.({
-      skuAndroid: options.skuAndroid,
-      packageNameAndroid: options.packageNameAndroid,
+      skuAndroid: resolvedOptions?.skuAndroid ?? undefined,
+      packageNameAndroid: resolvedOptions?.packageNameAndroid ?? undefined,
     });
     return;
   }
-  // iOS: Use manage subscriptions sheet (ignore returned purchases for deeplink parity)
   if (Platform.OS === 'ios') {
     try {
       await IAP.instance.showManageSubscriptionsIOS();
-    } catch {
-      // no-op
+    } catch (error) {
+      console.warn('[deepLinkToSubscriptions] Failed on iOS:', error);
     }
-    return;
   }
-  return;
 };
 
 /**
@@ -1412,21 +1266,6 @@ export const deepLinkToSubscriptions = async (
  * }
  * ```
  */
-export const getAppTransactionIOS = async (): Promise<string | null> => {
-  if (Platform.OS !== 'ios') {
-    throw new Error('getAppTransactionIOS is only available on iOS');
-  }
-
-  try {
-    // Call the native method to get app transaction
-    const appTransaction = await IAP.instance.getAppTransactionIOS();
-    return appTransaction;
-  } catch (error) {
-    console.error('Failed to get app transaction:', error);
-    throw error;
-  }
-};
-
 // Export subscription helpers
 export {
   getActiveSubscriptions,
@@ -1453,3 +1292,72 @@ export const acknowledgePurchase = acknowledgePurchaseAndroid;
  * @deprecated Use consumePurchaseAndroid instead
  */
 export const consumePurchase = consumePurchaseAndroid;
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+type NitroDiscountOfferRecord = NonNullable<
+  NonNullable<NitroPurchaseRequest['ios']>['withOffer']
+>;
+
+const toDiscountOfferRecordIOS = (
+  offer: DiscountOfferInputIOS | null | undefined,
+): NitroDiscountOfferRecord | undefined => {
+  if (!offer) {
+    return undefined;
+  }
+  return {
+    identifier: offer.identifier,
+    keyIdentifier: offer.keyIdentifier,
+    nonce: offer.nonce,
+    signature: offer.signature,
+    timestamp: String(offer.timestamp),
+  };
+};
+
+const toNitroProductType = (
+  type?: ProductTypeInput | ProductQueryType | null,
+): 'inapp' | 'subs' | 'all' => {
+  if (type === 'subs') {
+    return 'subs';
+  }
+  if (type === 'all') {
+    return 'all';
+  }
+  if (type === 'inapp') {
+    console.warn(LEGACY_INAPP_WARNING);
+    return 'inapp';
+  }
+  return 'inapp';
+};
+
+const isSubscriptionQuery = (type?: ProductQueryType | null): boolean =>
+  type === 'subs';
+
+const normalizeProductQueryType = (
+  type?: ProductQueryType | string | null,
+): ProductQueryType => {
+  if (type === 'all' || type === 'subs' || type === 'in-app') {
+    return type;
+  }
+
+  if (typeof type === 'string') {
+    const normalized = type.trim().toLowerCase().replace(/_/g, '-');
+
+    if (normalized === 'all') {
+      return 'all';
+    }
+    if (normalized === 'subs') {
+      return 'subs';
+    }
+    if (normalized === 'inapp') {
+      console.warn(LEGACY_INAPP_WARNING);
+      return 'in-app';
+    }
+    if (normalized === 'in-app') {
+      return 'in-app';
+    }
+  }
+  return 'in-app';
+};

--- a/src/specs/RnIap.nitro.ts
+++ b/src/specs/RnIap.nitro.ts
@@ -1,5 +1,22 @@
 import type {HybridObject} from 'react-native-nitro-modules';
-import type {RequestPurchaseResult} from '../types';
+// NOTE: This Nitro spec re-exports types from the generated schema (src/types.ts)
+// via type aliases to avoid duplicating structure. Nitro's codegen expects the
+// canonical `Nitro*` names defined here, so we keep the aliases rather than
+// removing the types entirely.
+import type {
+  AndroidSubscriptionOfferInput,
+  DeepLinkOptions,
+  MutationFinishTransactionArgs,
+  ProductCommon,
+  PurchaseCommon,
+  PurchaseOptions,
+  ReceiptValidationAndroidOptions,
+  ReceiptValidationProps,
+  ReceiptValidationResultAndroid,
+  RequestPurchaseIosProps,
+  RequestPurchaseResult,
+  RequestSubscriptionAndroidProps,
+} from '../types';
 
 // ╔══════════════════════════════════════════════════════════════════════════╗
 // ║                                  PARAMS                                  ║
@@ -7,22 +24,16 @@ import type {RequestPurchaseResult} from '../types';
 
 // Receipt validation parameters
 
-/**
- * Android-specific receipt validation options
- */
 export interface NitroReceiptValidationAndroidOptions {
-  packageName: string;
-  productToken: string;
-  accessToken: string;
-  isSub?: boolean;
+  accessToken: ReceiptValidationAndroidOptions['accessToken'];
+  isSub?: ReceiptValidationAndroidOptions['isSub'];
+  packageName: ReceiptValidationAndroidOptions['packageName'];
+  productToken: ReceiptValidationAndroidOptions['productToken'];
 }
 
-/**
- * Receipt validation parameters
- */
 export interface NitroReceiptValidationParams {
-  sku: string;
-  androidOptions?: NitroReceiptValidationAndroidOptions;
+  sku: ReceiptValidationProps['sku'];
+  androidOptions?: NitroReceiptValidationAndroidOptions | null;
 }
 
 // Purchase request parameters
@@ -30,41 +41,27 @@ export interface NitroReceiptValidationParams {
 /**
  * iOS-specific purchase request parameters
  */
-interface NitroRequestPurchaseIos {
-  sku: string;
-  andDangerouslyFinishTransactionAutomatically?: boolean;
-  appAccountToken?: string;
-  quantity?: number;
-  withOffer?: Record<string, string>;
+export interface NitroRequestPurchaseIos {
+  sku: RequestPurchaseIosProps['sku'];
+  andDangerouslyFinishTransactionAutomatically?: RequestPurchaseIosProps['andDangerouslyFinishTransactionAutomatically'];
+  appAccountToken?: RequestPurchaseIosProps['appAccountToken'];
+  quantity?: RequestPurchaseIosProps['quantity'];
+  withOffer?: Record<string, string> | null;
 }
 
-/**
- * Android subscription offer structure
- */
-interface NitroSubscriptionOffer {
-  sku: string;
-  offerToken: string;
+export interface NitroRequestPurchaseAndroid {
+  skus: RequestSubscriptionAndroidProps['skus'];
+  obfuscatedAccountIdAndroid?: RequestSubscriptionAndroidProps['obfuscatedAccountIdAndroid'];
+  obfuscatedProfileIdAndroid?: RequestSubscriptionAndroidProps['obfuscatedProfileIdAndroid'];
+  isOfferPersonalized?: RequestSubscriptionAndroidProps['isOfferPersonalized'];
+  subscriptionOffers?: AndroidSubscriptionOfferInput[] | null;
+  replacementModeAndroid?: RequestSubscriptionAndroidProps['replacementModeAndroid'];
+  purchaseTokenAndroid?: RequestSubscriptionAndroidProps['purchaseTokenAndroid'];
 }
 
-/**
- * Android-specific purchase request parameters
- */
-interface NitroRequestPurchaseAndroid {
-  skus: string[];
-  obfuscatedAccountIdAndroid?: string;
-  obfuscatedProfileIdAndroid?: string;
-  isOfferPersonalized?: boolean;
-  subscriptionOffers?: NitroSubscriptionOffer[];
-  replacementModeAndroid?: number;
-  purchaseTokenAndroid?: string;
-}
-
-/**
- * Unified purchase request with platform-specific options
- */
-interface NitroPurchaseRequest {
-  ios?: NitroRequestPurchaseIos;
-  android?: NitroRequestPurchaseAndroid;
+export interface NitroPurchaseRequest {
+  ios?: NitroRequestPurchaseIos | null;
+  android?: NitroRequestPurchaseAndroid | null;
 }
 
 // Available purchases parameters
@@ -72,26 +69,20 @@ interface NitroPurchaseRequest {
 /**
  * iOS-specific options for getting available purchases
  */
-interface NitroAvailablePurchasesIosOptions {
-  alsoPublishToEventListener?: boolean; // @deprecated Use alsoPublishToEventListenerIOS
-  onlyIncludeActiveItems?: boolean; // @deprecated Use onlyIncludeActiveItemsIOS
-  alsoPublishToEventListenerIOS?: boolean;
-  onlyIncludeActiveItemsIOS?: boolean;
+export interface NitroAvailablePurchasesIosOptions extends PurchaseOptions {
+  alsoPublishToEventListener?: boolean | null;
+  onlyIncludeActiveItems?: boolean | null;
 }
 
-/**
- * Android-specific options for getting available purchases
- */
-interface NitroAvailablePurchasesAndroidOptions {
-  type?: string; // 'inapp' or 'subs'
+type NitroAvailablePurchasesAndroidType = 'inapp' | 'subs';
+
+export interface NitroAvailablePurchasesAndroidOptions {
+  type?: NitroAvailablePurchasesAndroidType;
 }
 
-/**
- * Unified available purchases options with platform-specific parameters
- */
-interface NitroAvailablePurchasesOptions {
-  ios?: NitroAvailablePurchasesIosOptions;
-  android?: NitroAvailablePurchasesAndroidOptions;
+export interface NitroAvailablePurchasesOptions {
+  ios?: NitroAvailablePurchasesIosOptions | null;
+  android?: NitroAvailablePurchasesAndroidOptions | null;
 }
 
 // Transaction finish parameters
@@ -99,32 +90,29 @@ interface NitroAvailablePurchasesOptions {
 /**
  * iOS-specific parameters for finishing a transaction
  */
-interface NitroFinishTransactionIosParams {
+export interface NitroFinishTransactionIosParams {
   transactionId: string;
 }
 
 /**
  * Android-specific parameters for finishing a transaction
  */
-interface NitroFinishTransactionAndroidParams {
+export interface NitroFinishTransactionAndroidParams {
   purchaseToken: string;
-  isConsumable?: boolean;
+  isConsumable?: MutationFinishTransactionArgs['isConsumable'];
 }
 
 /**
  * Unified finish transaction parameters with platform-specific options
  */
-interface NitroFinishTransactionParams {
-  ios?: NitroFinishTransactionIosParams;
-  android?: NitroFinishTransactionAndroidParams;
+export interface NitroFinishTransactionParams {
+  ios?: NitroFinishTransactionIosParams | null;
+  android?: NitroFinishTransactionAndroidParams | null;
 }
 
-/**
- * Android deep link options for subscription management
- */
-interface NitroDeepLinkOptionsAndroid {
-  skuAndroid?: string;
-  packageNameAndroid?: string;
+export interface NitroDeepLinkOptionsAndroid {
+  skuAndroid?: DeepLinkOptions['skuAndroid'];
+  packageNameAndroid?: DeepLinkOptions['packageNameAndroid'];
 }
 
 // ╔══════════════════════════════════════════════════════════════════════════╗
@@ -136,10 +124,10 @@ interface NitroDeepLinkOptionsAndroid {
  */
 export interface NitroSubscriptionRenewalInfo {
   autoRenewStatus: boolean;
-  autoRenewPreference?: string;
-  expirationReason?: number;
-  gracePeriodExpirationDate?: number;
-  currentProductID?: string;
+  autoRenewPreference?: string | null;
+  expirationReason?: number | null;
+  gracePeriodExpirationDate?: number | null;
+  currentProductID?: string | null;
   platform: string;
 }
 
@@ -149,7 +137,7 @@ export interface NitroSubscriptionRenewalInfo {
 export interface NitroSubscriptionStatus {
   state: number;
   platform: string;
-  renewalInfo?: NitroSubscriptionRenewalInfo;
+  renewalInfo?: NitroSubscriptionRenewalInfo | null;
 }
 
 /**
@@ -163,108 +151,88 @@ export interface NitroPurchaseResult {
   purchaseToken?: string;
 }
 
-/**
- * iOS receipt validation result
- */
 export interface NitroReceiptValidationResultIOS {
   isValid: boolean;
   receiptData: string;
   jwsRepresentation: string;
-  latestTransaction?: NitroPurchase;
+  latestTransaction?: NitroPurchase | null;
 }
 
-/**
- * Android receipt validation result
- */
 export interface NitroReceiptValidationResultAndroid {
-  autoRenewing: boolean;
-  betaProduct: boolean;
-  cancelDate: number | null;
-  cancelReason: string;
-  deferredDate: number | null;
-  deferredSku: number | null;
-  freeTrialEndDate: number;
-  gracePeriodEndDate: number;
-  parentProductId: string;
-  productId: string;
-  productType: string;
-  purchaseDate: number;
-  quantity: number;
-  receiptId: string;
-  renewalDate: number;
-  term: string;
-  termSku: string;
-  testTransaction: boolean;
+  autoRenewing: ReceiptValidationResultAndroid['autoRenewing'];
+  betaProduct: ReceiptValidationResultAndroid['betaProduct'];
+  cancelDate: ReceiptValidationResultAndroid['cancelDate'];
+  cancelReason: ReceiptValidationResultAndroid['cancelReason'];
+  deferredDate: ReceiptValidationResultAndroid['deferredDate'];
+  deferredSku: ReceiptValidationResultAndroid['deferredSku'];
+  freeTrialEndDate: ReceiptValidationResultAndroid['freeTrialEndDate'];
+  gracePeriodEndDate: ReceiptValidationResultAndroid['gracePeriodEndDate'];
+  parentProductId: ReceiptValidationResultAndroid['parentProductId'];
+  productId: ReceiptValidationResultAndroid['productId'];
+  productType: ReceiptValidationResultAndroid['productType'];
+  purchaseDate: ReceiptValidationResultAndroid['purchaseDate'];
+  quantity: ReceiptValidationResultAndroid['quantity'];
+  receiptId: ReceiptValidationResultAndroid['receiptId'];
+  renewalDate: ReceiptValidationResultAndroid['renewalDate'];
+  term: ReceiptValidationResultAndroid['term'];
+  termSku: ReceiptValidationResultAndroid['termSku'];
+  testTransaction: ReceiptValidationResultAndroid['testTransaction'];
 }
 
-/**
- * Purchase data structure returned from native
- */
 export interface NitroPurchase {
-  // Common fields
-  id: string;
-  productId: string;
-  transactionDate: number;
-  purchaseToken?: string;
-  platform: string;
-  quantity: number;
-  purchaseState: string;
-  isAutoRenewing: boolean;
-
-  // iOS specific fields
-  quantityIOS?: number;
-  originalTransactionDateIOS?: number;
-  originalTransactionIdentifierIOS?: string;
-  appAccountToken?: string;
-
-  // Android specific fields
-  purchaseTokenAndroid?: string;
-  dataAndroid?: string;
-  signatureAndroid?: string;
-  autoRenewingAndroid?: boolean;
-  purchaseStateAndroid?: number;
-  isAcknowledgedAndroid?: boolean;
-  packageNameAndroid?: string;
-  obfuscatedAccountIdAndroid?: string;
-  obfuscatedProfileIdAndroid?: string;
+  id: PurchaseCommon['id'];
+  productId: PurchaseCommon['productId'];
+  transactionDate: PurchaseCommon['transactionDate'];
+  purchaseToken?: PurchaseCommon['purchaseToken'];
+  platform: PurchaseCommon['platform'];
+  quantity: PurchaseCommon['quantity'];
+  purchaseState: PurchaseCommon['purchaseState'];
+  isAutoRenewing: PurchaseCommon['isAutoRenewing'];
+  quantityIOS?: number | null;
+  originalTransactionDateIOS?: number | null;
+  originalTransactionIdentifierIOS?: string | null;
+  appAccountToken?: string | null;
+  purchaseTokenAndroid?: string | null;
+  dataAndroid?: string | null;
+  signatureAndroid?: string | null;
+  autoRenewingAndroid?: boolean | null;
+  purchaseStateAndroid?: number | null;
+  isAcknowledgedAndroid?: boolean | null;
+  packageNameAndroid?: string | null;
+  obfuscatedAccountIdAndroid?: string | null;
+  obfuscatedProfileIdAndroid?: string | null;
 }
 
-/**
- * Product data structure returned from native
- */
 export interface NitroProduct {
-  // Common fields
-  id: string;
-  title: string;
-  description: string;
+  id: ProductCommon['id'];
+  title: ProductCommon['title'];
+  description: ProductCommon['description'];
   type: string;
-  displayName?: string;
-  displayPrice?: string;
-  currency?: string;
-  price?: number;
-  platform: string;
-
+  displayName?: ProductCommon['displayName'];
+  displayPrice?: ProductCommon['displayPrice'];
+  currency?: ProductCommon['currency'];
+  price?: ProductCommon['price'];
+  platform: ProductCommon['platform'];
   // iOS specific fields
-  typeIOS?: string;
-  isFamilyShareableIOS?: boolean;
-  jsonRepresentationIOS?: string;
-  subscriptionPeriodUnitIOS?: string;
-  subscriptionPeriodNumberIOS?: number;
-  introductoryPriceIOS?: string;
-  introductoryPriceAsAmountIOS?: number;
-  introductoryPricePaymentModeIOS?: string;
-  introductoryPriceNumberOfPeriodsIOS?: number;
-  introductoryPriceSubscriptionPeriodIOS?: string;
-
+  typeIOS?: string | null;
+  isFamilyShareableIOS?: boolean | null;
+  jsonRepresentationIOS?: string | null;
+  introductoryPriceIOS?: string | null;
+  introductoryPriceAsAmountIOS?: number | null;
+  introductoryPriceNumberOfPeriodsIOS?: number | null;
+  introductoryPricePaymentModeIOS?: string | null;
+  introductoryPriceSubscriptionPeriodIOS?: string | null;
+  subscriptionPeriodNumberIOS?: number | null;
+  subscriptionPeriodUnitIOS?: string | null;
   // Android specific fields
-  originalPriceAndroid?: string;
-  originalPriceAmountMicrosAndroid?: number;
-  introductoryPriceValueAndroid?: number;
-  introductoryPriceCyclesAndroid?: number;
-  introductoryPricePeriodAndroid?: string;
-  subscriptionPeriodAndroid?: string;
-  freeTrialPeriodAndroid?: string;
-  subscriptionOfferDetailsAndroid?: string; // Android subscription offer details as JSON string
+  originalPriceAndroid?: string | null;
+  originalPriceAmountMicrosAndroid?: number | null;
+  introductoryPriceCyclesAndroid?: number | null;
+  introductoryPricePeriodAndroid?: string | null;
+  introductoryPriceValueAndroid?: number | null;
+  subscriptionPeriodAndroid?: string | null;
+  freeTrialPeriodAndroid?: string | null;
+  subscriptionOfferDetailsAndroid?: string | null;
 }
 
 // ╔══════════════════════════════════════════════════════════════════════════╗

--- a/src/types.ts
+++ b/src/types.ts
@@ -703,3 +703,77 @@ export interface SubscriptionStatusIOS {
 export interface VoidResult {
   success: boolean;
 }
+// -- Query helper types (auto-generated)
+export type QueryArgsMap = {
+  currentEntitlementIOS: QueryCurrentEntitlementIosArgs;
+  fetchProducts: QueryFetchProductsArgs;
+  getActiveSubscriptions: QueryGetActiveSubscriptionsArgs;
+  getAppTransactionIOS: never;
+  getAvailablePurchases: QueryGetAvailablePurchasesArgs;
+  getPendingTransactionsIOS: never;
+  getPromotedProductIOS: never;
+  getReceiptDataIOS: never;
+  getStorefrontIOS: never;
+  getTransactionJwsIOS: QueryGetTransactionJwsIosArgs;
+  hasActiveSubscriptions: QueryHasActiveSubscriptionsArgs;
+  isEligibleForIntroOfferIOS: QueryIsEligibleForIntroOfferIosArgs;
+  isTransactionVerifiedIOS: QueryIsTransactionVerifiedIosArgs;
+  latestTransactionIOS: QueryLatestTransactionIosArgs;
+  subscriptionStatusIOS: QuerySubscriptionStatusIosArgs;
+};
+
+export type QueryField<K extends keyof Query> =
+  QueryArgsMap[K] extends never
+    ? () => NonNullable<Query[K]>
+    : (args: QueryArgsMap[K]) => NonNullable<Query[K]>;
+
+export type QueryFieldMap = {
+  [K in keyof Query]?: QueryField<K>;
+};
+// -- End query helper types
+
+// -- Mutation helper types (auto-generated)
+export type MutationArgsMap = {
+  acknowledgePurchaseAndroid: MutationAcknowledgePurchaseAndroidArgs;
+  beginRefundRequestIOS: MutationBeginRefundRequestIosArgs;
+  clearTransactionIOS: never;
+  consumePurchaseAndroid: MutationConsumePurchaseAndroidArgs;
+  deepLinkToSubscriptions: MutationDeepLinkToSubscriptionsArgs;
+  endConnection: never;
+  finishTransaction: MutationFinishTransactionArgs;
+  initConnection: never;
+  presentCodeRedemptionSheetIOS: never;
+  requestPurchase: MutationRequestPurchaseArgs;
+  requestPurchaseOnPromotedProductIOS: never;
+  restorePurchases: never;
+  showManageSubscriptionsIOS: never;
+  syncIOS: never;
+  validateReceipt: MutationValidateReceiptArgs;
+};
+
+export type MutationField<K extends keyof Mutation> =
+  MutationArgsMap[K] extends never
+    ? () => NonNullable<Mutation[K]>
+    : (args: MutationArgsMap[K]) => NonNullable<Mutation[K]>;
+
+export type MutationFieldMap = {
+  [K in keyof Mutation]?: MutationField<K>;
+};
+// -- End mutation helper types
+
+// -- Subscription helper types (auto-generated)
+export type SubscriptionArgsMap = {
+  promotedProductIOS: never;
+  purchaseError: never;
+  purchaseUpdated: never;
+};
+
+export type SubscriptionField<K extends keyof Subscription> =
+  SubscriptionArgsMap[K] extends never
+    ? () => NonNullable<Subscription[K]>
+    : (args: SubscriptionArgsMap[K]) => NonNullable<Subscription[K]>;
+
+export type SubscriptionFieldMap = {
+  [K in keyof Subscription]?: SubscriptionField<K>;
+};
+// -- End subscription helper types

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,10 +126,7 @@ export enum ErrorCode {
   UserError = 'USER_ERROR'
 }
 
-export interface FetchProductsResult {
-  products?: (Product[] | null);
-  subscriptions?: (ProductSubscription[] | null);
-}
+export type FetchProductsResult = Product[] | ProductSubscription[] | null;
 
 export type IapEvent = 'promoted-product-ios' | 'purchase-error' | 'purchase-updated';
 
@@ -137,57 +134,46 @@ export type IapPlatform = 'android' | 'ios';
 
 export interface Mutation {
   /** Acknowledge a non-consumable purchase or subscription */
-  acknowledgePurchaseAndroid: Promise<VoidResult>;
+  acknowledgePurchaseAndroid: Promise<boolean>;
   /** Initiate a refund request for a product (iOS 15+) */
-  beginRefundRequestIOS: Promise<RefundResultIOS>;
+  beginRefundRequestIOS?: Promise<(string | null)>;
   /** Clear pending transactions from the StoreKit payment queue */
-  clearTransactionIOS: Promise<VoidResult>;
+  clearTransactionIOS: Promise<boolean>;
   /** Consume a purchase token so it can be repurchased */
-  consumePurchaseAndroid: Promise<VoidResult>;
+  consumePurchaseAndroid: Promise<boolean>;
   /** Open the native subscription management surface */
-  deepLinkToSubscriptions: Promise<VoidResult>;
+  deepLinkToSubscriptions: Promise<void>;
   /** Close the platform billing connection */
   endConnection: Promise<boolean>;
   /** Finish a transaction after validating receipts */
-  finishTransaction: Promise<VoidResult>;
+  finishTransaction: Promise<void>;
   /** Establish the platform billing connection */
   initConnection: Promise<boolean>;
   /** Present the App Store code redemption sheet */
-  presentCodeRedemptionSheetIOS: Promise<VoidResult>;
+  presentCodeRedemptionSheetIOS: Promise<boolean>;
   /** Initiate a purchase flow; rely on events for final state */
-  requestPurchase?: Promise<(RequestPurchaseResult | null)>;
+  requestPurchase?: Promise<(Purchase | Purchase[] | null)>;
   /** Purchase the promoted product surfaced by the App Store */
   requestPurchaseOnPromotedProductIOS: Promise<PurchaseIOS>;
   /** Restore completed purchases across platforms */
-  restorePurchases: Promise<VoidResult>;
+  restorePurchases: Promise<void>;
   /** Open subscription management UI and return changed purchases (iOS 15+) */
   showManageSubscriptionsIOS: Promise<PurchaseIOS[]>;
   /** Force a StoreKit sync for transactions (iOS 15+) */
-  syncIOS: Promise<VoidResult>;
+  syncIOS: Promise<boolean>;
   /** Validate purchase receipts with the configured providers */
   validateReceipt: Promise<ReceiptValidationResult>;
 }
 
 
-export interface MutationAcknowledgePurchaseAndroidArgs {
-  purchaseToken: string;
-}
 
+export type MutationAcknowledgePurchaseAndroidArgs = string;
 
-export interface MutationBeginRefundRequestIosArgs {
-  sku: string;
-}
+export type MutationBeginRefundRequestIosArgs = string;
 
+export type MutationConsumePurchaseAndroidArgs = string;
 
-export interface MutationConsumePurchaseAndroidArgs {
-  purchaseToken: string;
-}
-
-
-export interface MutationDeepLinkToSubscriptionsArgs {
-  options?: (DeepLinkOptions | null);
-}
-
+export type MutationDeepLinkToSubscriptionsArgs = (DeepLinkOptions | null) | undefined;
 
 export interface MutationFinishTransactionArgs {
   isConsumable?: (boolean | null);
@@ -195,14 +181,20 @@ export interface MutationFinishTransactionArgs {
 }
 
 
-export interface MutationRequestPurchaseArgs {
-  params: RequestPurchaseProps;
-}
+export type MutationRequestPurchaseArgs =
+  | {
+      /** Per-platform purchase request props */
+      request: RequestPurchasePropsByPlatforms;
+      type: 'in-app';
+    }
+  | {
+      /** Per-platform subscription request props */
+      request: RequestSubscriptionPropsByPlatforms;
+      type: 'subs';
+    };
 
 
-export interface MutationValidateReceiptArgs {
-  options: ReceiptValidationProps;
-}
+export type MutationValidateReceiptArgs = ReceiptValidationProps;
 
 export type PaymentModeIOS = 'empty' | 'free-trial' | 'pay-as-you-go' | 'pay-up-front';
 
@@ -440,13 +432,13 @@ export type PurchaseState = 'deferred' | 'failed' | 'pending' | 'purchased' | 'r
 
 export interface Query {
   /** Get current StoreKit 2 entitlements (iOS 15+) */
-  currentEntitlementIOS: Promise<EntitlementIOS[]>;
+  currentEntitlementIOS?: Promise<(PurchaseIOS | null)>;
   /** Retrieve products or subscriptions from the store */
-  fetchProducts: Promise<FetchProductsResult>;
+  fetchProducts: Promise<(Product[] | ProductSubscription[] | null)>;
   /** Get active subscriptions (filters by subscriptionIds when provided) */
   getActiveSubscriptions: Promise<ActiveSubscription[]>;
   /** Fetch the current app transaction (iOS 16+) */
-  getAppTransactionIOS?: Promise<(AppTransaction | null)>;
+  getAppTransactionIOS?: Promise<(string | null)>;
   /** Get all available purchases for the current user */
   getAvailablePurchases: Promise<Purchase[]>;
   /** Retrieve all pending transactions in the StoreKit queue */
@@ -454,14 +446,14 @@ export interface Query {
   /** Get the currently promoted product (iOS 11+) */
   getPromotedProductIOS?: Promise<(ProductIOS | null)>;
   /** Get base64-encoded receipt data for validation */
-  getReceiptDataIOS: Promise<string>;
+  getReceiptDataIOS?: Promise<(string | null)>;
   /** Get the current App Store storefront country code */
   getStorefrontIOS: Promise<string>;
   /** Get the transaction JWS (StoreKit 2) */
-  getTransactionJwsIOS: Promise<string>;
+  getTransactionJwsIOS?: Promise<(string | null)>;
   /** Check whether the user has active subscriptions */
   hasActiveSubscriptions: Promise<boolean>;
-  /** Check introductory offer eligibility for specific products */
+  /** Check introductory offer eligibility for a subscription group */
   isEligibleForIntroOfferIOS: Promise<boolean>;
   /** Verify a StoreKit 2 transaction signature */
   isTransactionVerifiedIOS: Promise<boolean>;
@@ -469,57 +461,33 @@ export interface Query {
   latestTransactionIOS?: Promise<(PurchaseIOS | null)>;
   /** Get StoreKit 2 subscription status details (iOS 15+) */
   subscriptionStatusIOS: Promise<SubscriptionStatusIOS[]>;
+  /** Validate a receipt for a specific product */
+  validateReceiptIOS: Promise<ReceiptValidationResultIOS>;
 }
 
 
-export interface QueryCurrentEntitlementIosArgs {
-  skus?: (string[] | null);
-}
 
+export type QueryCurrentEntitlementIosArgs = string;
 
-export interface QueryFetchProductsArgs {
-  params: ProductRequest;
-}
+export type QueryFetchProductsArgs = ProductRequest;
 
+export type QueryGetActiveSubscriptionsArgs = (string[] | null) | undefined;
 
-export interface QueryGetActiveSubscriptionsArgs {
-  subscriptionIds?: (string[] | null);
-}
+export type QueryGetAvailablePurchasesArgs = (PurchaseOptions | null) | undefined;
 
+export type QueryGetTransactionJwsIosArgs = string;
 
-export interface QueryGetAvailablePurchasesArgs {
-  options?: (PurchaseOptions | null);
-}
+export type QueryHasActiveSubscriptionsArgs = (string[] | null) | undefined;
 
+export type QueryIsEligibleForIntroOfferIosArgs = string;
 
-export interface QueryGetTransactionJwsIosArgs {
-  transactionId: string;
-}
+export type QueryIsTransactionVerifiedIosArgs = string;
 
+export type QueryLatestTransactionIosArgs = string;
 
-export interface QueryHasActiveSubscriptionsArgs {
-  subscriptionIds?: (string[] | null);
-}
+export type QuerySubscriptionStatusIosArgs = string;
 
-
-export interface QueryIsEligibleForIntroOfferIosArgs {
-  productIds: string[];
-}
-
-
-export interface QueryIsTransactionVerifiedIosArgs {
-  transactionId: string;
-}
-
-
-export interface QueryLatestTransactionIosArgs {
-  sku: string;
-}
-
-
-export interface QuerySubscriptionStatusIosArgs {
-  skus?: (string[] | null);
-}
+export type QueryValidateReceiptIosArgs = ReceiptValidationProps;
 
 export interface ReceiptValidationAndroidOptions {
   accessToken: string;
@@ -623,10 +591,7 @@ export interface RequestPurchasePropsByPlatforms {
   ios?: (RequestPurchaseIosProps | null);
 }
 
-export interface RequestPurchaseResult {
-  purchase?: (Purchase | null);
-  purchases?: (Purchase[] | null);
-}
+export type RequestPurchaseResult = Purchase | Purchase[] | null;
 
 export interface RequestSubscriptionAndroidProps {
   /** Personalized offer flag */
@@ -669,6 +634,7 @@ export interface Subscription {
   purchaseUpdated: Purchase;
 }
 
+
 export interface SubscriptionInfoIOS {
   introductoryOffer?: (SubscriptionOfferIOS | null);
   promotionalOffers?: (SubscriptionOfferIOS[] | null);
@@ -700,9 +666,8 @@ export interface SubscriptionStatusIOS {
   state: string;
 }
 
-export interface VoidResult {
-  success: boolean;
-}
+export type VoidResult = void;
+
 // -- Query helper types (auto-generated)
 export type QueryArgsMap = {
   currentEntitlementIOS: QueryCurrentEntitlementIosArgs;
@@ -720,12 +685,15 @@ export type QueryArgsMap = {
   isTransactionVerifiedIOS: QueryIsTransactionVerifiedIosArgs;
   latestTransactionIOS: QueryLatestTransactionIosArgs;
   subscriptionStatusIOS: QuerySubscriptionStatusIosArgs;
+  validateReceiptIOS: QueryValidateReceiptIosArgs;
 };
 
 export type QueryField<K extends keyof Query> =
   QueryArgsMap[K] extends never
     ? () => NonNullable<Query[K]>
-    : (args: QueryArgsMap[K]) => NonNullable<Query[K]>;
+    : undefined extends QueryArgsMap[K]
+      ? (args?: QueryArgsMap[K]) => NonNullable<Query[K]>
+      : (args: QueryArgsMap[K]) => NonNullable<Query[K]>;
 
 export type QueryFieldMap = {
   [K in keyof Query]?: QueryField<K>;
@@ -754,7 +722,9 @@ export type MutationArgsMap = {
 export type MutationField<K extends keyof Mutation> =
   MutationArgsMap[K] extends never
     ? () => NonNullable<Mutation[K]>
-    : (args: MutationArgsMap[K]) => NonNullable<Mutation[K]>;
+    : undefined extends MutationArgsMap[K]
+      ? (args?: MutationArgsMap[K]) => NonNullable<Mutation[K]>
+      : (args: MutationArgsMap[K]) => NonNullable<Mutation[K]>;
 
 export type MutationFieldMap = {
   [K in keyof Mutation]?: MutationField<K>;
@@ -771,7 +741,9 @@ export type SubscriptionArgsMap = {
 export type SubscriptionField<K extends keyof Subscription> =
   SubscriptionArgsMap[K] extends never
     ? () => NonNullable<Subscription[K]>
-    : (args: SubscriptionArgsMap[K]) => NonNullable<Subscription[K]>;
+    : undefined extends SubscriptionArgsMap[K]
+      ? (args?: SubscriptionArgsMap[K]) => NonNullable<Subscription[K]>
+      : (args: SubscriptionArgsMap[K]) => NonNullable<Subscription[K]>;
 
 export type SubscriptionFieldMap = {
   [K in keyof Subscription]?: SubscriptionField<K>;

--- a/src/utils/purchase.ts
+++ b/src/utils/purchase.ts
@@ -1,0 +1,32 @@
+import {normalizeErrorCodeFromNative} from './errorMapping';
+import type {NitroPurchaseResult} from '../specs/RnIap.nitro';
+
+export type PurchaseOperationContext =
+  | 'finishTransaction'
+  | 'acknowledgePurchaseAndroid'
+  | 'consumePurchaseAndroid';
+
+export const getSuccessFromPurchaseVariant = (
+  variant: NitroPurchaseResult | boolean,
+  context: PurchaseOperationContext,
+): boolean => {
+  if (typeof variant === 'boolean') {
+    return variant;
+  }
+
+  if (variant.responseCode === 0) {
+    return true;
+  }
+
+  const normalizedCode = normalizeErrorCodeFromNative(variant.code);
+  const errorPayload = {
+    code: normalizedCode,
+    nativeCode: variant.code,
+    message: variant.message || `Failed to ${context}`,
+    responseCode: variant.responseCode,
+    debugMessage: variant.debugMessage,
+    purchaseToken: variant.purchaseToken,
+  };
+
+  throw new Error(JSON.stringify(errorPayload));
+};


### PR DESCRIPTION
## Summary
* update the iOS hybrid module to return the optional RequestPurchaseResult expected by the generated Nitro spec

* rework the Android hybrid module to emit the new enum-based IapPlatform/PurchaseState values and adopt the latest Nitro parameter types for deep link and receipt validation APIs

* add a helper to translate OpenIAP purchase states and ensure Android-specific stubs compile against the refreshed spec