### PR TITLE
Add support for "auto-renewable-subscription" in iOS product type normalization

### DIFF
--- a/src/utils/type-bridge.ts
+++ b/src/utils/type-bridge.ts
@@ -70,6 +70,7 @@ function normalizeProductTypeIOS(value?: Nullable<string>): ProductTypeIOS {
       return 'non-consumable';
     case 'autorenewablesubscription':
     case 'auto_renewable_subscription':
+    case 'auto-renewable-subscription':
     case 'autorenewable':
       return 'auto-renewable-subscription';
     case 'nonrenewingsubscription':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for the hyphenated iOS product type input "auto-renewable-subscription," ensuring it’s recognized alongside existing variants.
  * Prevents misclassification and related errors when configuring iOS subscriptions, improving reliability for different input formats.
  * Enhances compatibility without affecting existing setups or workflows.
  * Backwards compatible; no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->