### PR TITLE
fix(android): prevent product data overwrite in fetchProducts with type 'all'

### DIFF
--- a/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -194,36 +194,15 @@ class HybridRnIap : HybridRnIapSpec() {
             val queryType = parseProductQueryType(type)
             val skusList = skus.toList()
 
-            val products: List<ProductCommon> = when (queryType) {
-                ProductQueryType.All -> {
-                    val collected = linkedMapOf<String, ProductCommon>()
-                    listOf(ProductQueryType.InApp, ProductQueryType.Subs).forEach { kind ->
-                        RnIapLog.payload(
-                            "fetchProducts.native",
-                            mapOf("skus" to skusList, "type" to kind.rawValue)
-                        )
-                        val fetched = openIap.fetchProducts(ProductRequest(skusList, kind)).productsOrEmpty()
-                        RnIapLog.result(
-                            "fetchProducts.native",
-                            fetched.map { mapOf("id" to it.id, "type" to it.type.rawValue) }
-                        )
-                        fetched.forEach { collected[it.id] = it }
-                    }
-                    collected.values.toList()
-                }
-                else -> {
-                    RnIapLog.payload(
-                        "fetchProducts.native",
-                        mapOf("skus" to skusList, "type" to queryType.rawValue)
-                    )
-                    val fetched = openIap.fetchProducts(ProductRequest(skusList, queryType)).productsOrEmpty()
-                    RnIapLog.result(
-                        "fetchProducts.native",
-                        fetched.map { mapOf("id" to it.id, "type" to it.type.rawValue) }
-                    )
-                    fetched
-                }
-            }
+            RnIapLog.payload(
+                "fetchProducts.native",
+                mapOf("skus" to skusList, "type" to queryType.rawValue)
+            )
+            val products = openIap.fetchProducts(ProductRequest(skusList, queryType)).productsOrEmpty()
+            RnIapLog.result(
+                "fetchProducts.native",
+                products.map { mapOf("id" to it.id, "type" to it.type.rawValue) }
+            )
 
             products.forEach { p -> productTypeBySku[p.id] = p.type.rawValue }
 


### PR DESCRIPTION
## Problem

When using `fetchProducts` with `type: 'all'` to query mixed product types (e.g., both InApp and Subscription SKUs), InApp products lose their price information.

### Reproduction Steps
1. Call `fetchProducts(['inapp_sku', 'subs_sku'], 'all')`
2. Check the returned InApp product
3. Observe that `price` field is `null` and `displayPrice`, `currency` fields are `""`

### Root Cause

The original implementation handled `ProductQueryType.All` by:
1. First querying InApp type → finds `inapp_sku` with complete price information
2. Then querying Subs type → queries with the same SKU, Google Play returns empty/incomplete data
3. Using `map[sku] = product` to unconditionally overwrite → valid InApp product data gets overwritten

```kotlin
// Original implementation
fetched.forEach { collected[it.id] = it }  // ❌ Unconditional overwrite
```

## Solution
OpenIAP's `fetchProducts` method already correctly implements `ProductQueryType.All` logic:
Uses processedIds to track already-processed product IDs
Prevents duplicate additions of the same product
Correctly handles mixed-type queries

Reference: [OpenIAP fetchProducts implementation](https://github.com/hyodotdev/openiap-google/blob/c0d224aebe34ee6baa1037fbef855cad6ae4781d/openiap/src/main/java/dev/hyo/openiap/OpenIapModule.kt#L149)

This PR removes the redundant manual implementation and directly uses OpenIAP's functionality.

## Testing

Tested in my app with the following scenarios:

- [x] Mixed InApp + Subs query (type: 'all') → Both product types now return complete information with correct pricing
- [x] InApp only query (type: 'inapp') → Works correctly
- [x] Subs only query (type: 'subs') → Works correctly

Before this fix, InApp products would return `{ displayPrice:"", currency:"", price:null }` when queried together with subscription products using type `'all'`. After this fix, all products maintain their complete data.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Streamlined in-app purchase product fetching into a single, consistent flow across product types.

- Performance
  - Reduced overhead by eliminating redundant aggregation, improving product load times.

- Stability
  - More consistent and reliable product retrieval for all product types.

- Observability
  - Simplified and consolidated logging for clearer diagnostics during product fetch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->